### PR TITLE
fix: Split name and prefix

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,5 +1,6 @@
 {
-  "name": "Cozy Notes",
+  "name": "Notes",
+  "name_prefix": "Cozy",
   "slug": "notes",
   "icon": "icon.svg",
   "categories": [],


### PR DESCRIPTION
We usually separate the `Cozy` from the name field to help formatting in the UI.