### PR TITLE
fix: Default title was not defined

### DIFF
--- a/src/lib/collab/stack-client.js
+++ b/src/lib/collab/stack-client.js
@@ -43,7 +43,7 @@ export class ServiceClient {
   }
 
   defaultTitle() {
-    new Date().toISOString()
+    return new Date().toISOString()
   }
 
   path(id, sub) {


### PR DESCRIPTION
Default title was missing because of a missing return in the function definition.
