### PR TITLE
feat: Adds an exponential backoff when failing

### DIFF
--- a/src/lib/collab/channel.js
+++ b/src/lib/collab/channel.js
@@ -1,11 +1,162 @@
 import { EventEmitter2 } from 'eventemitter2'
 import { getVersion, sendableSteps } from 'prosemirror-collab'
 
+const minimumBackoff = 128 // 128ms
+const maximumBackoff = 1000 * 60 * 5 // Max 5 minutes
+const failuresBeforeCatchup = 4
+
 export class Channel {
   constructor(config, serviceClient) {
     this.config = config
     this.service = serviceClient
     this.eventEmitter = new EventEmitter2()
+    this.resetBackoff()
+    this.initializeStepsQueue()
+    this.isSending = false
+  }
+
+  /**
+   * Reset the backoff
+   */
+  resetBackoff() {
+    this.backoff = 0
+    this.failures = 0
+  }
+
+  /**
+   * Increase the backoff
+   */
+  increaseBackoff() {
+    this.failures = this.failures + 1
+    if (this.failures % failuresBeforeCatchup == 0) {
+      this.emit('needcatchup', { failures: this.failures })
+    }
+
+    this.backoff = Math.max(
+      Math.min(this.backoff * 2, maximumBackoff),
+      minimumBackoff
+    )
+  }
+
+  /**
+   * Program something after backoff
+   * @returns {Promise}
+   */
+  afterBackoff() {
+    const fn = resolve => {
+      if (this.backoff < minimumBackoff) {
+        resolve()
+      } else {
+        window.setTimeout(resolve, this.backoff)
+      }
+    }
+    return new Promise(fn)
+  }
+
+  /**
+   * Initialize the steps queue
+   */
+  initializeStepsQueue() {
+    this.queuedStep = undefined
+  }
+
+  /**
+   * Enqueue steps
+   * @param {Function} getState - function to get a current proseMirror state
+   * @param {Object} state - proseMirror state
+   * @param {Object[]} localSteps - local steps to send
+   */
+  enqueueSteps({ getState, state, localSteps }) {
+    this.queuedStep = { getState, state, localSteps }
+  }
+
+  /**
+   * Dequeue steps
+   * @returns {getState, state, localSteps}
+   */
+  dequeueSteps() {
+    const queued = this.queuedStep
+    const getState = queued.getState
+    const state = queued.state || getState()
+    const localSteps = queued.localSteps ||
+      sendableSteps(state) || { steps: [] }
+    this.queuedStep = undefined
+
+    return { getState, state, localSteps }
+  }
+
+  /**
+   * Test if there is a queued step
+   * @returns {boolean}
+   */
+  hasQueuedSteps() {
+    return !!this.queuedStep
+  }
+
+  /**
+   * Rebase steps in queue
+   */
+  rebaseStepsInQueue() {
+    if (this.queuedStep) {
+      this.queuedStep = { getState: this.queuedStep.getState }
+    }
+  }
+
+  /**
+   * Program a push for new steps to the service
+   * @param {Function} getState - function to get a current proseMirror state
+   * @param {Object} state - proseMirror state
+   * @param {Object[]} localSteps - local steps to send
+   */
+  async sendSteps(getState, state, localSteps) {
+    this.enqueueSteps({ getState, state, localSteps })
+    await this.processQueue()
+  }
+
+  /**
+   * Send steps in queue
+   */
+  async processQueue() {
+    if (this.isSending) return
+    if (!this.hasQueuedSteps()) return
+
+    this.isSending = true
+    await this.afterBackoff()
+
+    const {
+      getState,
+      state,
+      localSteps: { steps }
+    } = this.dequeueSteps()
+    const version = getVersion(state)
+
+    // Don't send any steps before we're ready.
+    if (typeof version === undefined) return
+    // Nothing to do if no steps
+    if (steps.length === 0) return
+
+    try {
+      const { docId } = this.config
+      const response = await this.service.pushSteps(docId, version, steps)
+      this.rebaseStepsInQueue()
+      this.resetBackoff()
+      this.isSending = false
+      if (response && response.steps && response.steps.length > 0) {
+        this.emit('data', response)
+      }
+    } catch (err) {
+      if (this.hasQueuedSteps()) {
+        // will retry later with more steps
+        this.rebaseStepsInQueue()
+      } else {
+        // send again the current steps
+        this.enqueueSteps({ getState })
+      }
+      this.increaseBackoff()
+      this.isSending = false
+    }
+    // if ever there was something waiting
+    this.processQueue()
   }
 
   /**
@@ -24,53 +175,6 @@ export class Channel {
       doc,
       version
     })
-  }
-
-  debounce(getState) {
-    if (this.debounced) {
-      clearTimeout(this.debounced)
-    }
-
-    this.debounced = window.setTimeout(() => {
-      this.sendSteps(getState(), getState)
-    }, 250)
-  }
-
-  /**
-   * Send steps to service
-   */
-  async sendSteps(state, getState, localSteps) {
-    const { docId } = this.config
-
-    if (this.isSending) {
-      this.debounce(getState)
-      return
-    }
-
-    const version = getVersion(state)
-
-    // Don't send any steps before we're ready.
-    if (typeof version === undefined) {
-      return
-    }
-
-    const { steps } = localSteps || sendableSteps(state) || { steps: [] } // sendableSteps can return null..
-
-    if (steps.length === 0) {
-      return
-    }
-
-    this.isSending = true
-    try {
-      const response = await this.service.pushSteps(docId, version, steps)
-      this.isSending = false
-      if (response && response.steps && response.steps.length > 0) {
-        this.emit('data', response)
-      }
-    } catch (err) {
-      this.debounce(getState)
-      this.isSending = false
-    }
   }
 
   /**

--- a/src/lib/collab/channel.js
+++ b/src/lib/collab/channel.js
@@ -104,9 +104,12 @@ export class Channel {
 
   /**
    * Program a push for new steps to the service
-   * @param {Function} getState - function to get a current proseMirror state
-   * @param {Object} state - proseMirror state
-   * @param {Object[]} localSteps - local steps to send
+   * @param {Object} state - state from proseMirror internals
+   * @param {Function} getState - returns current proseMirror state
+   * @param {Object} localSteps - localSteps object from proseMirror internals
+   * Today the provider calling `sendSteps` do not fill the localSteps
+   * parameter. This parameter is however provisionned in the demo code from
+   * Atlaskit. I prefer not to remove it, in case we need it later.
    */
   async sendSteps(getState, state, localSteps) {
     this.enqueueSteps({ getState, state, localSteps })


### PR DESCRIPTION
Before this change, if the server does not accept our modifications, we try to send them in a loop, until success. We noticed that if the server had a bug, this would flood the stack with unstoppable requests.

With this change, we implement an exponential backoff. We wait 128ms after the first failure, then double this amount each time until we succeed (and go back to 0ms). There is a maximum waiting time of 5 minutes (whatever the failure is, we will retry every 5 minutes)

This change also implement a catchup. After 4 failures in a row in sending new data to the server, we try to manually fetch changes from the server. This may resolve some out of sync situations.