### PR TITLE
Add I18N

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@ coverage/
 
 
 # Locales
-**/locales/*
-!**/locales/en.json
+#**/locales/*
+#!**/locales/en.json
 
 
 # transifex

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@atlaskit/media-editor": "^37.0.0",
     "bufferutil": "^4.0.1",
     "cozy-bar": "^7.7.8",
-    "cozy-client": "^8.9.0",
+    "cozy-client": "^8.10.0",
     "cozy-device-helper": "^1.8.0",
     "cozy-doctypes": "^1.70.0",
     "cozy-realtime": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lodash.debounce": "^4.0.8",
     "react": "~16.8.1",
     "react-dom": "~16.8.1",
-    "react-intl": "^2.8.0",
+    "react-intl": "2.9.0",
     "react-router-dom": "^5.1.2",
     "socket.io": "^2.2.0",
     "socket.io-client": "^2.2.0",

--- a/src/components/notes/add.jsx
+++ b/src/components/notes/add.jsx
@@ -5,6 +5,7 @@ import { withClient } from 'cozy-client'
 import { withRouter } from 'react-router-dom'
 
 import Button from 'cozy-ui/react/Button'
+import { translate } from 'cozy-ui/react/I18n'
 
 import { schemaOrdered } from '../../lib/collab/schema'
 import { generateReturnUrlToNotesIndex } from '../../lib/utils'
@@ -43,6 +44,7 @@ class Add extends Component {
 
   render() {
     const { isWorking } = this.state
+    const { t } = this.props
     return (
       <div>
         <Button
@@ -50,7 +52,7 @@ class Add extends Component {
           type="submit"
           busy={isWorking}
           icon="plus"
-          label="ajouter une note"
+          label={t('Notes.Add.add_note')}
           extension="narrow"
         />
       </div>
@@ -59,4 +61,4 @@ class Add extends Component {
 }
 
 // get mutations from the client to use createDocument
-export default withClient(withRouter(Add))
+export default translate()(withClient(withRouter(Add)))

--- a/src/components/notes/editor-loading.jsx
+++ b/src/components/notes/editor-loading.jsx
@@ -6,15 +6,17 @@ import HeaderMenu from '../header_menu'
 
 import Spinner from 'cozy-ui/react/Spinner'
 import Button from 'cozy-ui/react/Button'
+import { translate } from 'cozy-ui/react/I18n'
 
-export default function EditorLoading() {
+function EditorLoading(props) {
+  const { t } = props
   const left = (
     <Button
       icon="back"
       tag={Link}
       to="/"
       className="sto-app-back"
-      label="Retour à la liste"
+      label={t('Notes.EditorLoading.back_to_list')}
       subtle
     />
   )
@@ -25,3 +27,5 @@ export default function EditorLoading() {
     </div>
   )
 }
+
+export default translate()(EditorLoading)

--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -8,13 +8,14 @@ import Textarea from 'cozy-ui/react/Textarea'
 import editorConfig from './editor_config'
 import BackFromEditing from './back_from_editing'
 import HeaderMenu from '../header_menu'
+import { translate } from 'cozy-ui/react/I18n'
 
 function updateTextareaHeight(target) {
   target.style.height = 'inherit'
   target.style.height = `${target.scrollHeight}px`
 }
 
-export default function EditorView(props) {
+function EditorView(props) {
   const {
     defaultValue,
     onTitleChange,
@@ -22,7 +23,8 @@ export default function EditorView(props) {
     defaultTitle,
     title,
     collabProvider,
-    returnUrl
+    returnUrl,
+    t
   } = props
 
   const titleEl = useRef(null)
@@ -52,7 +54,7 @@ export default function EditorView(props) {
           defaultValue={defaultValue}
           {...editorConfig}
           appearance="full-page"
-          placeholder="Que voulez-vous dire ?"
+          placeholder={t('Notes.EditorView.main_placeholder')}
           shouldFocus={true}
           contentComponents={
             <WithEditorActions
@@ -76,3 +78,5 @@ export default function EditorView(props) {
     </article>
   )
 }
+
+export default translate()(EditorView)

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -10,143 +10,147 @@ import ServiceClient from '../../lib/collab/stack-client'
 
 import { getShortNameFromClient, getParentFolderLink } from '../../lib/utils.js'
 
-const Editor = withClient(function(props) {
-  const { client, noteId } = props
-  const userName = useMemo(
-    () => props.userName || getShortNameFromClient(client),
-    [props.userName]
-  )
+import { translate } from 'cozy-ui/react/I18n'
 
-  // alias for later shortcuts
-  const docId = noteId
-  const userId = userName
-  const cozyClient = client
+const Editor = translate()(
+  withClient(function(props) {
+    const { client, noteId, t } = props
+    const userName = useMemo(
+      () => props.userName || getShortNameFromClient(client),
+      [props.userName]
+    )
 
-  // state
-  const [loading, setLoading] = useState(true)
-  const [doc, setDoc] = useState(undefined)
-  const [title, setTitle] = useState(undefined)
+    // alias for later shortcuts
+    const docId = noteId
+    const userId = userName
+    const cozyClient = client
 
-  // plugins and config
-  const serviceClient = useMemo(
-    () => {
-      return new ServiceClient({ userId, userName, cozyClient })
-    },
-    [noteId]
-  )
-  const docVersion = doc && doc.version
-  //console.log("docVersion", doc, doc && doc.version, docVersion)
-  const collabProvider = useMemo(
-    () => {
-      //console.log("collab provider memo", docVersion)
-      if (docVersion !== undefined) {
-        //console.log('new collabProvider')
-        const provider = new CollabProvider(
-          { version: doc.version, docId },
-          serviceClient
-        )
-        return {
-          useNativePlugin: true,
-          provider: Promise.resolve(provider),
-          inviteToEditHandler: () => undefined,
-          isInviteToEditButtonSelected: false,
-          userId: serviceClient.getSessionId()
-        }
-      } else {
-        return null
-      }
-    },
-    [noteId, docVersion, userName, serviceClient]
-  )
-  //console.log("end collabProviderMemo", collabProvider)
+    // state
+    const [loading, setLoading] = useState(true)
+    const [doc, setDoc] = useState(undefined)
+    const [title, setTitle] = useState(undefined)
 
-  // fetch the actual note on load
-  useEffect(
-    () => {
-      const fn = async function() {
-        try {
-          if (!loading) {
-            setLoading(true)
+    // plugins and config
+    const serviceClient = useMemo(
+      () => {
+        return new ServiceClient({ userId, userName, cozyClient })
+      },
+      [noteId]
+    )
+    const docVersion = doc && doc.version
+    //console.log("docVersion", doc, doc && doc.version, docVersion)
+    const collabProvider = useMemo(
+      () => {
+        //console.log("collab provider memo", docVersion)
+        if (docVersion !== undefined) {
+          //console.log('new collabProvider')
+          const provider = new CollabProvider(
+            { version: doc.version, docId },
+            serviceClient
+          )
+          return {
+            useNativePlugin: true,
+            provider: Promise.resolve(provider),
+            inviteToEditHandler: () => undefined,
+            isInviteToEditButtonSelected: false,
+            userId: serviceClient.getSessionId()
           }
-          const doc = await serviceClient.getDoc(noteId)
-          setTitle(doc.title || '')
-          setDoc(doc)
-        } catch (e) {
-          setTitle(false)
-          setDoc(false)
+        } else {
+          return null
         }
-        setLoading(false)
-      }
-      fn()
-    },
-    [noteId]
-  )
+      },
+      [noteId, docVersion, userName, serviceClient]
+    )
+    //console.log("end collabProviderMemo", collabProvider)
 
-  // callbacks
-  const onContentChange = useCallback(() => null, [noteId])
-  const onLocalTitleChange = useCallback(
-    e => {
-      const newTitle = e.target.value
-      const modifiedTitle = newTitle
-      if (title != modifiedTitle) {
-        setTitle(modifiedTitle)
-        serviceClient.setTitle(noteId, modifiedTitle)
+    // fetch the actual note on load
+    useEffect(
+      () => {
+        const fn = async function() {
+          try {
+            if (!loading) {
+              setLoading(true)
+            }
+            const doc = await serviceClient.getDoc(noteId)
+            setTitle(doc.title || '')
+            setDoc(doc)
+          } catch (e) {
+            setTitle(false)
+            setDoc(false)
+          }
+          setLoading(false)
+        }
+        fn()
+      },
+      [noteId]
+    )
+
+    // callbacks
+    const onContentChange = useCallback(() => null, [noteId])
+    const onLocalTitleChange = useCallback(
+      e => {
+        const newTitle = e.target.value
+        const modifiedTitle = newTitle
+        if (title != modifiedTitle) {
+          setTitle(modifiedTitle)
+          serviceClient.setTitle(noteId, modifiedTitle)
+        }
+      },
+      [noteId, setTitle, serviceClient]
+    )
+    const onRemoteTitleChange = useCallback(
+      modifiedTitle => {
+        if (title != modifiedTitle) {
+          setTitle(modifiedTitle)
+        }
+      },
+      [noteId, setTitle]
+    )
+    useMemo(
+      () => {
+        serviceClient.onTitleUpdated(noteId, onRemoteTitleChange)
+      },
+      [onRemoteTitleChange, serviceClient]
+    )
+    // Failure in loading the note ?
+    useEffect(() => {
+      if (!loading && !doc) {
+        // eslint-disable-next-line no-console
+        console.warn(`Could not load note ${noteId}`)
+        props.history.push(`/`)
       }
-    },
-    [noteId, setTitle, serviceClient]
-  )
-  const onRemoteTitleChange = useCallback(
-    modifiedTitle => {
-      if (title != modifiedTitle) {
-        setTitle(modifiedTitle)
-      }
-    },
-    [noteId, setTitle]
-  )
-  useMemo(
-    () => {
-      serviceClient.onTitleUpdated(noteId, onRemoteTitleChange)
-    },
-    [onRemoteTitleChange, serviceClient]
-  )
-  // Failure in loading the note ?
-  useEffect(() => {
-    if (!loading && !doc) {
-      // eslint-disable-next-line no-console
-      console.warn(`Could not load note ${noteId}`)
-      props.history.push(`/`)
+    })
+
+    const returnUrl = useMemo(
+      () => {
+        if (props.returnUrl !== undefined) {
+          return props.returnUrl
+        } else if (doc) {
+          return getParentFolderLink(client, doc.file)
+        } else {
+          return props.returnUrl
+        }
+      },
+      [props.returnUrl, doc]
+    )
+
+    // rendering
+    if (loading || !doc) {
+      return <EditorLoading />
+    } else {
+      return (
+        <EditorView
+          onTitleChange={onLocalTitleChange}
+          onContentChange={onContentChange}
+          collabProvider={collabProvider}
+          defaultTitle={t('Notes.Editor.title_placeholder')}
+          defaultValue={{ ...doc.doc, version: doc.version }}
+          title={title && title.length > 0 ? title : undefined}
+          returnUrl={returnUrl}
+        />
+      )
     }
   })
-
-  const returnUrl = useMemo(
-    () => {
-      if (props.returnUrl !== undefined) {
-        return props.returnUrl
-      } else if (doc) {
-        return getParentFolderLink(client, doc.file)
-      } else {
-        return props.returnUrl
-      }
-    },
-    [props.returnUrl, doc]
-  )
-
-  // rendering
-  if (loading || !doc) {
-    return <EditorLoading />
-  } else {
-    return (
-      <EditorView
-        onTitleChange={onLocalTitleChange}
-        onContentChange={onContentChange}
-        collabProvider={collabProvider}
-        defaultTitle={'Ici votre titre…'}
-        defaultValue={{ ...doc.doc, version: doc.version }}
-        title={title && title.length > 0 ? title : undefined}
-        returnUrl={returnUrl}
-      />
-    )
-  }
-})
+)
 
 export default Editor

--- a/src/components/notes/list.jsx
+++ b/src/components/notes/list.jsx
@@ -1,18 +1,23 @@
 import React from 'react'
 
-import Spinner from 'cozy-ui/react/Spinner'
-import { Link } from 'react-router-dom'
-
-import ListItemText from 'cozy-ui/react/ListItemText'
-import Button from 'cozy-ui/react/Button'
-import Icon from 'cozy-ui/react/Icon'
 import { MainTitle } from 'cozy-ui/react/Text'
 
 import Add from './add'
 
 import HeaderMenu from '../header_menu.jsx'
 
+/*
+
+import Spinner from 'cozy-ui/react/Spinner'
+import { Link } from 'react-router-dom'
+
+import ListItemText from 'cozy-ui/react/ListItemText'
+import Button from 'cozy-ui/react/Button'
+import Icon from 'cozy-ui/react/Icon'
+
 import icon from '../../assets/icons/icon-note-32.svg'
+
+
 
 const titleWithDefault = () => {}
 
@@ -77,17 +82,6 @@ const List = props => {
   )
 }
 
-const ListHeader = () => {
-  return (
-    <>
-      <HeaderMenu
-        left={<MainTitle tag="h1">Mes notes</MainTitle>}
-        right={<Add />}
-      />
-    </>
-  )
-}
-
 const ConnectedList = props => {
   const { data, fetchStatus } = props.notes
   // cozy-client statuses
@@ -103,6 +97,19 @@ const ConnectedList = props => {
         </div>
       )}
     </div>
+  )
+}
+
+*/
+
+const ListHeader = () => {
+  return (
+    <>
+      <HeaderMenu
+        left={<MainTitle tag="h1">Mes notes</MainTitle>}
+        right={<Add />}
+      />
+    </>
   )
 }
 

--- a/src/lib/collab/provider.js
+++ b/src/lib/collab/provider.js
@@ -213,6 +213,7 @@ export class CollabProvider {
       )
       this.emit('data', { json: steps, version, userIds })
     } else {
+      // eslint-disable-next-line no-console
       console.warn(
         'Collab.Provider: processRemoteData no steps ? ',
         steps,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,4 +1,18 @@
 {
+  "Notes": {
+    "Add": {
+      "add_note": "Add a note"
+    },
+    "EditorLoading": {
+      "back_to_list": "Back to the list"
+    },
+    "EditorView": {
+      "main_placeholder": "Write anything…"
+    },
+    "Editor": {
+      "title_placeholder": "Here is your title"
+    }
+  },
   "Error": {
     "unshared_title": "This share is no longer active",
     "unshared_text": "The owner may have revoked this share. You can no longer edit a note at this address."

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,0 +1,20 @@
+{
+  "Notes": {
+    "Add": {
+      "add_note": "Ajouter une note"
+    },
+    "EditorLoading": {
+      "back_to_list": "Retour à la liste"
+    },
+    "EditorView": {
+      "main_placeholder": "Écrivez ce que vous souhaitez…"
+    },
+    "Editor": {
+      "title_placeholder": "Ici votre titre"
+    }
+  },
+  "Error": {
+    "unshared_title": "The partage n'est plus actif",
+    "unshared_text": "Le propriétaire a peut-être révoqué ce partage. Vous ne pouvez plus éditer de note à cette adresse."
+  }
+}

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -7,7 +7,6 @@ import { IntlProvider, addLocaleData } from 'react-intl'
 import CozyClient, { CozyProvider } from 'cozy-client'
 import { render } from 'react-dom'
 import { I18n } from 'cozy-ui/react/I18n'
-import { schema } from 'components/notes'
 import IsPublic from 'components/IsPublic'
 
 let appLocale
@@ -32,7 +31,7 @@ const renderApp = function(client, isPublic) {
       lang={appLocale}
       dictRequire={appLocale => require(`locales/${appLocale}`)}
     >
-	  <IntlProvider locale={appLocale} messages={locales[appLocale].atlaskit}>
+      <IntlProvider locale={appLocale} messages={locales[appLocale].atlaskit}>
         <CozyProvider client={client}>
           <IsPublic.Provider value={isPublic}>
             <App isPublic={isPublic} />
@@ -116,7 +115,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const client = new CozyClient({
     uri: `${protocol}//${data.cozyDomain}`,
     token: token,
-    schema,
     appMetadata: {
       slug: appSlug,
       version: appVersion

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -3,6 +3,7 @@
 import 'styles'
 
 import React from 'react'
+import { IntlProvider, addLocaleData } from 'react-intl'
 import CozyClient, { CozyProvider } from 'cozy-client'
 import { render } from 'react-dom'
 import { I18n } from 'cozy-ui/react/I18n'
@@ -10,18 +11,34 @@ import { schema } from 'components/notes'
 import IsPublic from 'components/IsPublic'
 
 let appLocale
+const locales = {
+  en: {
+    react: require('react-intl/locale-data/en'),
+    atlaskit: require('@atlaskit/editor-core/dist/cjs/i18n/en').default
+  },
+  fr: {
+    react: require('react-intl/locale-data/fr'),
+    atlaskit: require('@atlaskit/editor-core/dist/cjs/i18n/fr').default
+  }
+}
+addLocaleData(locales.en.react)
+addLocaleData(locales.fr.react)
+
 const renderApp = function(client, isPublic) {
   const App = require('components/app').default
+
   render(
     <I18n
       lang={appLocale}
       dictRequire={appLocale => require(`locales/${appLocale}`)}
     >
-      <CozyProvider client={client}>
-        <IsPublic.Provider value={isPublic}>
-          <App isPublic={isPublic} />
-        </IsPublic.Provider>
-      </CozyProvider>
+	  <IntlProvider locale={appLocale} messages={locales[appLocale].atlaskit}>
+        <CozyProvider client={client}>
+          <IsPublic.Provider value={isPublic}>
+            <App isPublic={isPublic} />
+          </IsPublic.Provider>
+        </CozyProvider>
+      </IntlProvider>
     </I18n>,
     document.querySelector('[role=application]')
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -4752,7 +4752,7 @@ cozy-bar@^7.7.8:
     redux-persist "5.10.0"
     redux-thunk "2.3.0"
 
-cozy-client@^8.9.0:
+cozy-client@^8.10.0:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-8.10.0.tgz#6a49e7065d0d283153c5570559d90a5f9c7045a4"
   integrity sha512-RuSgRqw6KIUz8AIvMdmboahLTb4oHeugpbODw2uXzc545PbrDaHrv7On8SeeITpzIOKfyzatN2Gxj9gzds+DaA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -12220,7 +12220,7 @@ react-input-autosize@^2.2.1, react-input-autosize@^2.2.2:
   dependencies:
     prop-types "^15.5.8"
 
-react-intl@^2.8.0:
+react-intl@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.9.0.tgz#c97c5d17d4718f1575fdbd5a769f96018a3b1843"
   integrity sha512-27jnDlb/d2A7mSJwrbOBnUgD+rPep+abmoJE511Tf8BnoONIAUehy/U1zZCHGO17mnOwMWxqN4qC0nW11cD6rA==


### PR DESCRIPTION
* Adds I18N for the Atlaskit Editor.

I added only FR and EN. If we want to benefit for all their locales, we should implement some kind of dynamic import as embedding everything would be too heavy

* Adds translations for our own components

Still, only FR and EN, no Transifex

* Cleanup for linter 