### PR TITLE
fix: Correctly load cozy-ui

### DIFF
--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -1,6 +1,12 @@
-@import '../../node_modules/cozy-ui/transpiled/react/stylesheet.css'
+@import '~cozy-ui/transpiled/react/stylesheet.css'
 
 // @stylint off
+
+/* Temporary fix waiting for https://github.com/cozy/cozy-bar/pull/675 */
+.coz-nav-apps-btns-main {
+    font-size: 1rem;
+}
+
 
 html {
     --documentMaxWidth: 48rem;


### PR DESCRIPTION
The app name in the Cozy-bar was at 11px instead of 1rem. This is the default for a browser and should have been overrided by cozy-ui.

Cozy-ui main stylesheet was missing. Fixed