### PR TITLE
chore: Build on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ node_js:
 branches:
   only:
     - master
+    # tags
+    - /^v\d+\.\d+\.\d+(\-beta.\d+)?$/
 env:
   global:
     # REGISTRY_TOKEN


### PR DESCRIPTION
Travis only runs on master, but for releases we also want to run on tags.