### PR TITLE
chore: Build without "v" prefix on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
   only:
     - master
     # tags
-    - /^v\d+\.\d+\.\d+(\-beta.\d+)?$/
+    - /^\d+\.\d+\.\d+(\-beta.\d+)?$/
 env:
   global:
     # REGISTRY_TOKEN


### PR DESCRIPTION
We want to build tags even if they don't start with a `v`.