### PR TITLE
feat: Add link to the Notes folder on Cozy Drive

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-dom": "~16.8.1",
     "react-intl": "2.9.0",
     "react-router-dom": "^5.1.2",
+    "snarkdown": "^1.2.2",
     "socket.io": "^2.2.0",
     "socket.io-client": "^2.2.0",
     "utf-8-validate": "^5.0.2",

--- a/src/components/notes/hooks/useReferencedFolderForNote.jsx
+++ b/src/components/notes/hooks/useReferencedFolderForNote.jsx
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react'
+import { CozyFolder } from 'cozy-doctypes'
+import { getFullLink } from 'lib/utils'
+
+const notesFolderDocument = {
+  _type: 'io.cozy.apps',
+  _id: 'io.cozy.apps/notes'
+}
+
+const useReferencedFolderForNote = client => {
+  const [notesFolder, setNotesFolder] = useState(null)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const driveUrl = getFullLink(client)
+      try {
+        setNotesFolder(driveUrl)
+        const referencedFolder = await CozyFolder.getReferencedFolders(
+          notesFolderDocument
+        )
+        const folderUrl = getFullLink(client, referencedFolder[0]._id)
+        setNotesFolder(folderUrl)
+      } catch (error) {
+        setNotesFolder(driveUrl)
+      }
+    }
+    fetchData()
+  }, [])
+
+  return {
+    notesFolder
+  }
+}
+
+export default useReferencedFolderForNote

--- a/src/components/notes/list.jsx
+++ b/src/components/notes/list.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import snarkdown from 'snarkdown'
 
 import { MainTitle } from 'cozy-ui/react/Text'
 import {
@@ -11,25 +12,43 @@ import {
 } from 'cozy-ui/react/Table'
 import Empty from 'cozy-ui/react/Empty'
 import Stack from 'cozy-ui/react/Stack'
+
 import { translate } from 'cozy-ui/react/I18n'
 import { withBreakpoints } from 'cozy-ui/transpiled/react'
-
+import { withClient } from 'cozy-client'
 import Add from 'components/notes/add'
 import icon from 'assets/icons/icon_note_empty.svg'
 import 'components/notes/list.styl'
+import useReferencedFolderForNote from 'components/notes/hooks/useReferencedFolderForNote'
 
-const EmptyComponent = translate()(({ t }) => (
-  <div className="empty">
-    <Empty
-      id="empty"
-      icon={icon}
-      title={t('Notes.Empty.welcome')}
-      text={t('Notes.Empty.after_created')}
-    >
-      <Add className="u-mt-1" />
-    </Empty>
-  </div>
-))
+const EmptyComponent = translate()(
+  withClient(({ t, client }) => {
+    const { notesFolder } = useReferencedFolderForNote(client)
+    return (
+      <div className="empty">
+        <Empty
+          id="empty"
+          icon={icon}
+          title={t('Notes.Empty.welcome')}
+          text={
+            <p
+              className="u-mb-half"
+              dangerouslySetInnerHTML={{
+                __html: snarkdown(
+                  t('Notes.Empty.after_created', {
+                    notesFolder
+                  })
+                )
+              }}
+            />
+          }
+        >
+          <Add className="u-mt-1" />
+        </Empty>
+      </div>
+    )
+  })
+)
 
 const List = translate()(({ t }) => (
   <Table>

--- a/src/components/notes/list.styl
+++ b/src/components/notes/list.styl
@@ -6,7 +6,8 @@ $PADDING_TABLE_FIRST_COLUMN=1rem
     transform: translateZ(0)
     height: 500px
     display: flex
-
+    a
+        color: var(--dodgerBlue)
 .titlePadding
     padding-left $PADDING_TABLE_FIRST_COLUMN
 .tableCell 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -48,11 +48,11 @@ function getFolderLink(id) {
   return `/folder/${id.replace(/-/g, '')}`
 }
 
-function getFullLink(client, id) {
+export function getFullLink(client, id = null) {
   const cozyURL = new URL(client.getStackClient().uri)
   const { cozySubdomainType } = client.getInstanceOptions()
   const driveSlug = 'drive'
-  const pathForDrive = getFolderLink(id)
+  const pathForDrive = id !== null ? getFolderLink(id) : ''
 
   const webUrl = generateWebLink({
     cozyUrl: cozyURL.origin,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -21,7 +21,7 @@
     },
     "Empty": {
       "welcome": "Welcome on Cozy Notes",
-      "after_created": "Once your Note is created, you can find it in your Cozy Drive"
+      "after_created": "Once your Note is created, you can find it in your [**Cozy Drive**](%{notesFolder})"
     }
   },
   "Error": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -21,7 +21,7 @@
     },
     "Empty": {
       "welcome": "Bienvenue sur Cozy Notes",
-      "after_created": "Une fois votre note créée, il vous est possible de la retrouver dans Cozy Drive"
+      "after_created": "Une fois votre note créée, il vous est possible de la retrouver dans [**Cozy Drive**](%{notesFolder})"
     }
   },
   "Error": {

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -7,6 +7,8 @@ import { IntlProvider, addLocaleData } from 'react-intl'
 import CozyClient, { CozyProvider } from 'cozy-client'
 import { render } from 'react-dom'
 import { I18n } from 'cozy-ui/react/I18n'
+import { Document } from 'cozy-doctypes'
+
 import IsPublic from 'components/IsPublic'
 import { getDataset, getDataOrDefault, getToken } from 'lib/initFromDom'
 
@@ -77,6 +79,9 @@ document.addEventListener('DOMContentLoaded', () => {
       version: appVersion
     }
   })
+  if (!Document.cozyClient) {
+    Document.registerClient(client)
+  }
 
   if (!isPublic) {
     // initialize the bar, common of all applications, it allows

--- a/yarn.lock
+++ b/yarn.lock
@@ -13454,6 +13454,11 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+snarkdown@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/snarkdown/-/snarkdown-1.2.2.tgz#0cfe2f3012b804de120fc0c9f7791e869c59cc74"
+  integrity sha1-DP4vMBK4BN4SD8DJ93kehpxZzHQ=
+
 socket.io-adapter@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz#2a805e8a14d6372124dd9159ad4502f8cb07f06b"


### PR DESCRIPTION
This PR adds a link to the `Notes` folder created by the stack. We use the `referenced_folder` to fetch the folder. 

If the folder is not found (ATM we have a bug in the stack https://github.com/cozy/cozy-stack/pull/2287) we fallback to the Drive URL. 

I used markdown to put the URL in the message. But it comes with a drawback: we can't style the link... WDYT? 

<img width="528" alt="Capture d’écran 2019-12-18 à 17 54 48" src="https://user-images.githubusercontent.com/1107936/71106342-827e3200-21bf-11ea-8bf6-754d5d655c00.png">
