### PR TITLE
fix: Move descriptions to locales

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -12,16 +12,6 @@
     "name": "Cozy Cloud",
     "url": "https://cozy.io"
   },
-  "locales": {
-    "en": {
-      "short_description": "Cozy Notes is the application for saving, editing and managing all your notes in your Cozy.",
-      "long_description": "Create your notes, save them and find them in one click in your Cozy. Share ideas with anyone you want in a private and secure space. \n\nWith Cozy Notes, you can easily:\n\n-- Create your own notes\n-- Easily edit your notes\n-- Access your notes directly from your Cozy Drive application."
-    },
-    "fr": {
-      "short_description": "Cozy Notes est l’application de sauvegarde, d’édition et de gestion de tous vos notes dans votre Cozy.",
-      "long_description": "Créez vos notes, sauvegardez-les et retrouvez-les en un clin d’oeil dans votre Cozy. Partagez des idées avec qui vous voulez dans un espace privé et sécurisé. \n\nAvec Cozy Notes, vous pouvez facilement :\n\n- Créer vos propres notes\n- Éditer facilement vos notes\n- Accéder à vos notes directement depuis votre application Cozy Drive."
-    }
-  },
   "screenshots": [
     "screenshots/fr/screenshot01.png",
     "screenshots/fr/screenshot02.png"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -27,5 +27,9 @@
   "Error": {
     "unshared_title": "This share is no longer active",
     "unshared_text": "The owner may have revoked this share. You can no longer edit a note at this address."
+  },
+  "manifest": {
+    "short_description": "Cozy Notes is the application for saving, editing and managing all your notes in your Cozy.",
+    "long_description": "Create your notes, save them and find them in one click in your Cozy. Share ideas with anyone you want in a private and secure space. \n\nWith Cozy Notes, you can easily:\n\n-- Create your own notes\n-- Easily edit your notes\n-- Access your notes directly from your Cozy Drive application."
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -27,5 +27,9 @@
   "Error": {
     "unshared_title": "Le partage n'est plus actif",
     "unshared_text": "Le propriétaire a peut-être révoqué ce partage. Vous ne pouvez plus éditer de note à cette adresse."
+  },
+  "manifest": {
+    "short_description": "Cozy Notes est l’application de sauvegarde, d’édition et de gestion de tous vos notes dans votre Cozy.",
+    "long_description": "Créez vos notes, sauvegardez-les et retrouvez-les en un clin d’oeil dans votre Cozy. Partagez des idées avec qui vous voulez dans un espace privé et sécurisé. \n\nAvec Cozy Notes, vous pouvez facilement :\n\n- Créer vos propres notes\n- Éditer facilement vos notes\n- Accéder à vos notes directement depuis votre application Cozy Drive."
   }
 }


### PR DESCRIPTION
cozy-scripts wants the manifest locales in the translation files, it strips the existing `locales` field from the manifest.