### PR TITLE
feat: Have the title on the tab bar of the browser

### DIFF
--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -8,9 +8,18 @@ import EditorLoading from './editor-loading'
 import CollabProvider from '../../lib/collab/provider'
 import ServiceClient from '../../lib/collab/stack-client'
 
-import { getShortNameFromClient, getParentFolderLink } from '../../lib/utils.js'
+import {
+  getShortNameFromClient,
+  getParentFolderLink,
+  getAppFullName
+} from '../../lib/utils.js'
 
 import { translate } from 'cozy-ui/react/I18n'
+
+function setPageTitle(appFullName, title) {
+  document.title =
+    title && title != '' ? `${appFullName} - ${title}` : appFullName
+}
 
 const Editor = translate()(
   withClient(function(props) {
@@ -19,6 +28,7 @@ const Editor = translate()(
       () => props.userName || getShortNameFromClient(client),
       [props.userName]
     )
+    const appFullName = useMemo(getAppFullName)
 
     // alias for later shortcuts
     const docId = noteId
@@ -120,6 +130,13 @@ const Editor = translate()(
         props.history.push(`/`)
       }
     })
+
+    useEffect(
+      () => {
+        setPageTitle(appFullName, title)
+      },
+      [title]
+    )
 
     const returnUrl = useMemo(
       () => {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -4,6 +4,9 @@ import {
   generateWebLink,
   generateUniversalLink
 } from 'cozy-ui/transpiled/react/AppLinker'
+import { getDataset, getDataOrDefault } from './initFromDom'
+
+import manifest from '../../manifest.webapp'
 
 export function getShortNameFromClient(client) {
   const url = new URL(client.getStackClient().uri)
@@ -79,4 +82,14 @@ export function getFullLink(client, id = null) {
 
 export function getParentFolderLink(client, file) {
   return getFullLink(client, getParentFolderId(file))
+}
+
+export function getAppFullName() {
+  const dataset = getDataset()
+  const appNamePrefix = getDataOrDefault(
+    dataset.cozyAppNamePrefix || manifest.name_prefix,
+    ''
+  )
+  const appName = getDataOrDefault(dataset.cozyAppName, manifest.name)
+  return appNamePrefix != '' ? `${appNamePrefix} ${appName}` : appName
 }


### PR DESCRIPTION
The browser tab is now named with the title of the document. This will help the awesome bar of Firefox and Chrome, and will allow user to put the page in their favorites