### PR TITLE
fix: Safari height issue

### DIFF
--- a/src/components/notes/List/List.jsx
+++ b/src/components/notes/List/List.jsx
@@ -16,7 +16,7 @@ import NoteRow from 'components/notes/List/NoteRow'
 import Add from 'components/notes/add'
 
 const EmptyTableRow = () => (
-  <TableRow className="tableRowEmpty">
+  <TableRow className="tableSpecialRow">
     <TableCell className="tableCellEmpty">
       <EmptyComponent />
     </TableCell>
@@ -24,7 +24,7 @@ const EmptyTableRow = () => (
 )
 
 const LoadingTableRow = () => (
-  <TableRow className="tableRowEmpty">
+  <TableRow className="tableSpecialRow">
     <TableCell className="tableCellEmpty u-ta-center">
       <Spinner size="xxlarge" />
     </TableCell>
@@ -32,7 +32,7 @@ const LoadingTableRow = () => (
 )
 
 const AddNoteRow = () => (
-  <TableRow className="tableRowEmpty">
+  <TableRow className="tableSpecialRow">
     <TableCell className="tableCellEmpty u-ta-center">
       <Add />
     </TableCell>

--- a/src/components/notes/List/list.styl
+++ b/src/components/notes/List/list.styl
@@ -11,8 +11,9 @@ $PADDING_TABLE_FIRST_COLUMN=1rem
         color: var(--dodgerBlue)
 .titlePadding
     padding-left $PADDING_TABLE_FIRST_COLUMN
-.tableRowEmpty
+.tableSpecialRow
     flex 1
+    height 100%
     //Cozy UI tables add border bottom to the latest child.
     //Since when we display the empty row we have only one,
     //let's hide it


### PR DESCRIPTION
Safari has an old bug with flex:1. We need 100% height 