### PR TITLE
feat: Don't show link to back when loading a note

### DIFF
--- a/src/components/notes/editor-loading.jsx
+++ b/src/components/notes/editor-loading.jsx
@@ -1,31 +1,13 @@
 import React from 'react'
 
-import { Link } from 'react-router-dom'
-
-import HeaderMenu from '../header_menu'
-
 import Spinner from 'cozy-ui/react/Spinner'
-import Button from 'cozy-ui/react/Button'
-import { translate } from 'cozy-ui/react/I18n'
 
-function EditorLoading(props) {
-  const { t } = props
-  const left = (
-    <Button
-      icon="back"
-      tag={Link}
-      to="/"
-      className="sto-app-back"
-      label={t('Notes.EditorLoading.back_to_list')}
-      subtle
-    />
-  )
+function EditorLoading() {
   return (
     <div>
-      <HeaderMenu left={left} />
       <Spinner size="xxlarge" middle />
     </div>
   )
 }
 
-export default translate()(EditorLoading)
+export default EditorLoading


### PR DESCRIPTION
The loading screen for the editor did have a weird UI with a non-styled link back to the home page and an incomplete header bar.

It's now with a simple cozy-bar and a spinner in the content.