### PR TITLE
tests: Fix test command

### DIFF
--- a/index.spec.jsx
+++ b/index.spec.jsx
@@ -1,0 +1,5 @@
+describe('first test', () => {
+  it('should test', () => {
+    expect(true).toBe(true)
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   moduleNameMapper: {
     '\\.(png|gif|jpe?g|svg)$': '<rootDir>/test/__mocks__/fileMock.js',
     // identity-obj-proxy module is installed by cozy-scripts
-    styles: 'identity-obj-proxy'
+    '\\.(css|styl)$': 'identity-obj-proxy'
   },
   transformIgnorePatterns: ['node_modules/(?!cozy-ui)'],
   globals: {


### PR DESCRIPTION
We had an error when we tried to run an empty test. This error was the result of a not enough restrictive moduleNameMapper.

This is not the first time, we should pay attention to this. 