### PR TITLE
fix: Adds again the necessary stylesheets

### DIFF
--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -1,5 +1,7 @@
 /* global cozy */
-
+import 'cozy-ui/dist/cozy-ui.utils.min.css'
+import 'cozy-ui/transpiled/react/stylesheet.css'
+import 'cozy-sharing/dist/stylesheet.css'
 import 'styles'
 
 import React from 'react'
@@ -15,7 +17,6 @@ import {
   getDataOrDefault,
   getPublicSharecode
 } from 'lib/initFromDom'
-import 'cozy-ui/transpiled/react/stylesheet.css'
 
 const manifest = require('../../../manifest.webapp')
 


### PR DESCRIPTION
The sharing button was not going green when the note was shared. The "copy link" button didn't have the correct style.

During the last merge with master, we lost a few CSS. Here is the fix