### PR TITLE
Fix/android link

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "react-dom": "~16.8.1",
     "react-intl": "2.9.0",
     "react-router-dom": "^5.1.2",
-    "snarkdown": "^1.2.2",
     "socket.io": "^2.2.0",
     "socket.io-client": "^2.2.0",
     "url-search-params-polyfill": "^7.0.1",

--- a/src/components/notes/List/EmptyComponent.jsx
+++ b/src/components/notes/List/EmptyComponent.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import snarkdown from 'snarkdown'
 import { translate } from 'cozy-ui/react/I18n'
 import Empty from 'cozy-ui/react/Empty'
 import { withClient } from 'cozy-client'
@@ -8,6 +7,7 @@ import Add from 'components/notes/add'
 import icon from 'assets/icons/icon_note_empty.svg'
 import useReferencedFolderForNote from 'hooks/useReferencedFolderForNote'
 
+import AppLinker from 'cozy-ui/react/AppLinker'
 const EmptyComponent = ({ t, client }) => {
   const { notesFolder } = useReferencedFolderForNote(client)
   return (
@@ -17,16 +17,19 @@ const EmptyComponent = ({ t, client }) => {
         icon={icon}
         title={t('Notes.Empty.welcome')}
         text={
-          <p
-            className="u-mb-half"
-            dangerouslySetInnerHTML={{
-              __html: snarkdown(
-                t('Notes.Empty.after_created', {
-                  notesFolder
-                })
+          <AppLinker href={notesFolder} slug="drive">
+            {({ href, onClick }) => {
+              return (
+                <span className="u-mb-half">
+                  {t('Notes.Empty.after_created')}{' '}
+                  <a href={href} onClick={onClick}>
+                    Cozy Drive
+                  </a>
+                  .
+                </span>
               )
             }}
-          />
+          </AppLinker>
         }
       >
         <Add className="u-mt-1" />

--- a/src/components/notes/back_from_editing.jsx
+++ b/src/components/notes/back_from_editing.jsx
@@ -2,17 +2,27 @@ import React, { useContext } from 'react'
 import { Link } from 'react-router-dom'
 import { Button, ButtonLink } from 'cozy-ui/react/Button'
 import IsPublicContext from 'components/IsPublicContext'
+import AppLinker from 'cozy-ui/react/AppLinker'
+import { getFolderLink, getParentFolderId } from 'lib/utils'
 
-export default function BackFromEditing({ returnUrl }) {
+export default function BackFromEditing({ returnUrl, file }) {
   const isPublic = useContext(IsPublicContext)
   if (returnUrl) {
+    const nativePath = getFolderLink(getParentFolderId(file))
     return (
-      <ButtonLink
-        icon="previous"
-        href={returnUrl}
-        className="sto-app-back"
-        subtle
-      />
+      <AppLinker slug="drive" href={returnUrl} nativePath={nativePath}>
+        {({ onClick, href }) => {
+          return (
+            <ButtonLink
+              icon="previous"
+              onClick={onClick}
+              href={href}
+              className="sto-app-back"
+              subtle
+            />
+          )
+        }}
+      </AppLinker>
     )
   } else if (!isPublic) {
     return (

--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -23,7 +23,7 @@ function EditorView(props) {
     title,
     collabProvider,
     leftComponent,
-    actions,
+    rightComponent,
     t
   } = props
 
@@ -46,7 +46,7 @@ function EditorView(props) {
       <HeaderMenu
         left={leftComponent}
         className="note-header-menu--editing"
-        right={actions}
+        right={rightComponent}
       />
       <section className="note-editor-container">
         <Editor

--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -6,7 +6,6 @@ import { MainTitle } from 'cozy-ui/react/Text'
 import Textarea from 'cozy-ui/react/Textarea'
 
 import editorConfig from 'components/notes/editor_config'
-import BackFromEditing from 'components/notes/back_from_editing'
 import HeaderMenu from 'components/header_menu'
 import { translate } from 'cozy-ui/react/I18n'
 
@@ -23,7 +22,8 @@ function EditorView(props) {
     defaultTitle,
     title,
     collabProvider,
-    returnUrl,
+    leftComponent,
+    actions,
     t
   } = props
 
@@ -44,9 +44,9 @@ function EditorView(props) {
     <article className="note-article">
       <style>#coz-bar {'{ display: none }'}</style>
       <HeaderMenu
-        left={<BackFromEditing returnUrl={returnUrl} />}
+        left={leftComponent}
         className="note-header-menu--editing"
-        right={props.actions}
+        right={actions}
       />
       <section className="note-editor-container">
         <Editor

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -195,7 +195,7 @@ const Editor = translate()(
           leftComponent={
             <BackFromEditing returnUrl={returnUrl} file={doc.file} />
           }
-          actions={!isPublic && <SharingWidget file={doc.file} />}
+          rightComponent={!isPublic && <SharingWidget file={doc.file} />}
         />
       )
     } else {

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -8,10 +8,11 @@ import React, {
 
 import { withClient } from 'cozy-client'
 
-import EditorView from './editor-view'
+import EditorView from 'components/notes/editor-view'
 import EditorLoading from 'components/notes/editor-loading'
 import EditorLoadingError from 'components/notes/editor-loading-error'
 import SharingWidget from 'components/notes/sharing'
+import BackFromEditing from 'components/notes/back_from_editing'
 
 import IsPublicContext from 'components/IsPublicContext'
 
@@ -191,7 +192,9 @@ const Editor = translate()(
           defaultTitle={t('Notes.Editor.title_placeholder')}
           defaultValue={{ ...doc.doc, version: doc.version }}
           title={title && title.length > 0 ? title : undefined}
-          returnUrl={returnUrl}
+          leftComponent={
+            <BackFromEditing returnUrl={returnUrl} file={doc.file} />
+          }
           actions={!isPublic && <SharingWidget file={doc.file} />}
         />
       )

--- a/src/hooks/useReferencedFolderForNote.jsx
+++ b/src/hooks/useReferencedFolderForNote.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { CozyFolder } from 'cozy-doctypes'
-import { getFullLink } from 'lib/utils'
+import { getDriveLink } from 'lib/utils'
 
 const notesFolderDocument = {
   _type: 'io.cozy.apps',
@@ -12,13 +12,13 @@ const useReferencedFolderForNote = client => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const driveUrl = getFullLink(client)
+      const driveUrl = getDriveLink(client)
       try {
         setNotesFolder(driveUrl)
         const referencedFolder = await CozyFolder.getReferencedFolders(
           notesFolderDocument
         )
-        const folderUrl = getFullLink(client, referencedFolder[0]._id)
+        const folderUrl = getDriveLink(client, referencedFolder[0]._id)
         setNotesFolder(folderUrl)
       } catch (error) {
         setNotesFolder(driveUrl)

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,9 +1,5 @@
 import get from 'lodash/get'
-import { isMobile } from 'cozy-device-helper'
-import {
-  generateWebLink,
-  generateUniversalLink
-} from 'cozy-ui/transpiled/react/AppLinker'
+import { generateWebLink } from 'cozy-ui/transpiled/react/AppLinker'
 import { getDataset, getDataOrDefault } from './initFromDom'
 import { schemaOrdered } from 'lib/collab/schema'
 
@@ -48,11 +44,11 @@ export function getParentFolderId(file) {
   return file.relationships.parent.data.id
 }
 
-function getFolderLink(id) {
+export function getFolderLink(id) {
   return `/folder/${id.replace(/-/g, '')}`
 }
 
-export function getFullLink(client, id = null) {
+export function getDriveLink(client, id = null) {
   const cozyURL = new URL(client.getStackClient().uri)
   const { cozySubdomainType } = client.getInstanceOptions()
   const driveSlug = 'drive'
@@ -65,24 +61,11 @@ export function getFullLink(client, id = null) {
     nativePath: pathForDrive
   })
 
-  /** If no mobile, then return the fallback directly. No need
-   * for the universal link
-   */
-  if (!isMobile()) {
-    return webUrl
-  }
-
-  const urlWithUL = generateUniversalLink({
-    slug: driveSlug,
-    fallbackUrl: webUrl,
-    nativePath: pathForDrive,
-    subDomainType: cozySubdomainType
-  })
-  return urlWithUL
+  return webUrl
 }
 
 export function getParentFolderLink(client, file) {
-  return getFullLink(client, getParentFolderId(file))
+  return getDriveLink(client, getParentFolderId(file))
 }
 
 export function getAppFullName() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -18,7 +18,7 @@
     },
     "Empty": {
       "welcome": "Welcome on Cozy Notes",
-      "after_created": "Once your Note is created, you can find it in your [**Cozy Drive**](%{notesFolder})"
+      "after_created": "Once your Note is created, you can find it in your "
     }
   },
   "Error": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -18,7 +18,7 @@
     },
     "Empty": {
       "welcome": "Bienvenue sur Cozy Notes",
-      "after_created": "Une fois votre note créée, il vous est possible de la retrouver dans [**Cozy Drive**](%{notesFolder})"
+      "after_created": "Une fois votre note créée, il vous est possible de la retrouver dans "
     }
   },
   "Error": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13546,11 +13546,6 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-snarkdown@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/snarkdown/-/snarkdown-1.2.2.tgz#0cfe2f3012b804de120fc0c9f7791e869c59cc74"
-  integrity sha1-DP4vMBK4BN4SD8DJ93kehpxZzHQ=
-
 socket.io-adapter@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz#2a805e8a14d6372124dd9159ad4502f8cb07f06b"


### PR DESCRIPTION
We currently have an issue with our UniversalLink on Android. The JSON file was missing on the server resulting in a "not verified" state for our link.mycozy.cloud. 

To bypass this issue (before having a fix for it), we use the AppLinker from UI. AppLinker has a special case for Android and use the customSchema instead of the Universalink. With the custom schema we open the app without asking something to the user ;). 

Since `Editor` can be standalone in a near future, we don't want to give it access to the `file` object. So I added a `LeftComponent` props we can create in `EditorView` where we have access to `file`.

I ended removing snarkdown since we need the `onClick` attr on the `a` and we can't do that with markdown. 