### PR TITLE
fix: EditorBar issue on mobile

### DIFF
--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -9,7 +9,7 @@ import editorConfig from 'components/notes/editor_config'
 import BackFromEditing from 'components/notes/back_from_editing'
 import HeaderMenu from 'components/header_menu'
 import { translate } from 'cozy-ui/react/I18n'
-
+import styles from 'components/notes/editor-view.styl'
 function updateTextareaHeight(target) {
   target.style.height = 'inherit'
   target.style.height = `${target.scrollHeight}px`
@@ -41,7 +41,7 @@ function EditorView(props) {
   useEffect(() => updateTextareaHeight(titleEl.current), [])
 
   return (
-    <article className="note-article">
+    <article className={styles['note-article']}>
       <style>#coz-bar {'{ display: none }'}</style>
       <HeaderMenu
         left={<BackFromEditing returnUrl={returnUrl} />}

--- a/src/components/notes/editor-view.styl
+++ b/src/components/notes/editor-view.styl
@@ -1,0 +1,10 @@
+@require 'settings/breakpoints.styl'
+
+$COZY_BAR_HEIGHT=-3rem
+.note-article
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    
+    +medium-screen()
+        margin-top $COZY_BAR_HEIGHT

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -180,11 +180,6 @@ html .akEditor > div:first-child > div:first-child > div:first-child > div:first
   align-items: center;
 }
 
-html .note-article {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-}
 
 html .note-title {
     flex-grow: 1;


### PR DESCRIPTION
Since `Layout` adds a `before` with an height of 3rem (https://github.com/cozy/cozy-ui/blob/master/stylus/objects/layouts.styl#L105) on medium-screen to give to the bar the needed place and since we hide the cozy-bar, we had to remove this. I just used a -3rem marginTop 