### PR TITLE
fix: Remove the hide of o-layout-before. Change list's margin

### DIFF
--- a/src/components/notes/List/index.jsx
+++ b/src/components/notes/List/index.jsx
@@ -20,7 +20,7 @@ const ListView = ({ breakpoints: { isMobile }, client }) => {
 
   return (
     <>
-      <Stack className="u-mt-1 u-mt-3-m">
+      <Stack className="u-mt-1 u-mt-0-m">
         <div
           className={`${
             styles.appHeader

--- a/src/components/notes/editor-view.styl
+++ b/src/components/notes/editor-view.styl
@@ -1,10 +1,15 @@
 @require 'settings/breakpoints.styl'
 
+/* Cozy-UI Layout adds a ::before with an height of 3rem 
+(https://github.com/cozy/cozy-ui/blob/master/stylus/objects/layouts.styl#L105) 
+on medium-screen to give to the bar the needed place. Since we hide the cozy-bar
+on the editor-view we remove this margin
+*/
 $COZY_BAR_HEIGHT=-3rem
 .note-article
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    
-    +medium-screen()
+    display flex
+    flex-direction column
+    height 100%
+
+    +medium-screen()	
         margin-top $COZY_BAR_HEIGHT

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -67,13 +67,6 @@ html .akEditor > div:first-child {
     height: calc(100% - 48px);
 }
 
-/* div o-layout : do not add the space for the cozy-bar */
-html [role=application] > div::before,
-html [role=application] > div::after, {
-    height: auto !important;
-    display: none !important;
-}
-
 /* prose mirror toolbar in the upper bar */
 html .akEditor > div:first-child {
     margin-left: var(--note-header-margin-left);


### PR DESCRIPTION
Avant, on cachait le ::before de cozy-ui pour lui mettre une hauteur de 0 principalement parce que nous cachons la cozy-bar sur l'`editeur-view`. Ça faisait sens quand on avait qu'une seule vue. Maintenant nous avons aussi le listing des notes, et cette vue doit hériter des styles traditionnels de UI à savoir ce fameux before de 3rem. 

Vu que l'editeur-view a un comportement particulier, je préfère lui appliquer le -3rem en margin que d'appliquer le comportement normal de UI sur les autres vues (donc j'ai retiré le mt-3 sur la liste qui n'a plus sens) 