### PR TITLE
feat: Sync on leaving a note

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "cozy-realtime": "^3.2.3",
     "cozy-scripts": "^2.0.2",
     "cozy-sharing": "^1.5.2",
-    "cozy-ui": "^28.5.0",
+    "cozy-ui": "^28.12.0",
     "eslint-config-cozy-app": "^1.3.3",
     "lodash": "^4.17.15",
     "react": "~16.8.1",

--- a/src/lib/collab/stack-client.js
+++ b/src/lib/collab/stack-client.js
@@ -115,6 +115,14 @@ export class ServiceClient {
   }
 
   /**
+   * Force the note to be written to the io.cozy.files now
+   * @param {uuid} docId - note id
+   */
+  async sync(docId) {
+    await this.stackClient.fetchJSON('POST', this.path(docId, 'sync'))
+  }
+
+  /**
    * Change the title of a note
    * @param {uuid} docId
    * @param {string} title

--- a/src/lib/collab/stack-client.spec.js
+++ b/src/lib/collab/stack-client.spec.js
@@ -766,4 +766,19 @@ describe('ServiceClient', () => {
       expect(lastCall[2]).toHaveProperty('data.attributes.type', 'telepointer')
     })
   })
+
+  describe('sync', () => {
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    it('should call the server', async () => {
+      const service = new ServiceClient({ userId, cozyClient })
+      await service.sync(docId)
+      expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalledWith(
+        'POST',
+        `/notes/${docId}/sync`
+      )
+    })
+  })
 })

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -24,7 +24,7 @@ export function getReturnUrl() {
 
 export const generateReturnUrlToNotesIndex = doc => {
   const url = new URL(window.location)
-  url.searchParams.append(returnUrlKey, window.location.origin)
+  url.searchParams.set(returnUrlKey, '#/')
   url.hash = `#/n/${doc.id}`
   return url
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4963,10 +4963,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@^28.5.0:
-  version "28.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-28.6.0.tgz#adf7011f60e2abe8959ce8102fd89df43b437b40"
-  integrity sha512-vurqenjQZMz6SPKTtLzQPq8v1V04Fl+kPWp+0u9KUon9u6thVeW7Qr3seLT/9Uo/oiIZSzX4n4/AYlkKpSVPxw==
+cozy-ui@^28.12.0:
+  version "28.12.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-28.12.0.tgz#182d9c16330ef3096ecfdd4f86100140ac2d605b"
+  integrity sha512-+PxXzNy8+lm8L3hILUMYGVGPH/AQFEEPLs6QKhaeDPRzVJHFekvCk40phDwYW4/fVEyPLXx7844zrMLUZFxuMQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"
@@ -9908,13 +9908,6 @@ minilog@3.1.0, minilog@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/minilog/-/minilog-3.1.0.tgz#d2d0f1887ca363d1acf0ea86d5c4df293b3fb675"
   integrity sha1-0tDxiHyjY9Gs8OqG1cTfKTs/tnU=
-  dependencies:
-    microee "0.0.6"
-
-"minilog@git+https://github.com/cozy/minilog.git#master":
-  version "3.1.0"
-  uid f01f7d9dfe20981177dd34b9662c2f077d818f82
-  resolved "git+https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
   dependencies:
     microee "0.0.6"
 


### PR DESCRIPTION
With this change, we send a sync() request to the server
when leaving a note. This will allows the server to always
have files names and content up to date when we finish
to edit a note (instead of having to wait a few minutes).

Collateral: We now go back to the index with an anchor
and not by reloading the full page.
