### PR TITLE
Deploy on tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,6 @@ deploy:
     repo: cozy/cozy-notes
     skip-cleanup: true
     # publish stable or beta versions using Github Releases (git tag)
-    script: DEPLOY_BRANCH=build && yarn cozyPublish
+    script: DEPLOY_BRANCH=build && yarn deploy && yarn cozyPublish
     on:
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,6 @@ deploy:
     repo: cozy/cozy-notes
     skip-cleanup: true
     # publish stable or beta versions using Github Releases (git tag)
-    script: DEPLOY_BRANCH=build && yarn deploy && yarn cozyPublish
+    script: DEPLOY_BRANCH=ci-build && yarn deploy && yarn cozyPublish
     on:
       tags: true


### PR DESCRIPTION
When running a travis job from a tag, we were not deploying the build output to github before publishing.