### PR TITLE
fix: Set default value to Folderurl

### DIFF
--- a/src/hooks/useReferencedFolderForNote.jsx
+++ b/src/hooks/useReferencedFolderForNote.jsx
@@ -8,20 +8,18 @@ const notesFolderDocument = {
 }
 
 const useReferencedFolderForNote = client => {
-  const [notesFolder, setNotesFolder] = useState(null)
+  const [notesFolder, setNotesFolder] = useState(getDriveLink(client))
 
   useEffect(() => {
     const fetchData = async () => {
-      const driveUrl = getDriveLink(client)
       try {
-        setNotesFolder(driveUrl)
         const referencedFolder = await CozyFolder.getReferencedFolders(
           notesFolderDocument
         )
         const folderUrl = getDriveLink(client, referencedFolder[0]._id)
         setNotesFolder(folderUrl)
       } catch (error) {
-        setNotesFolder(driveUrl)
+        setNotesFolder(getDriveLink(client))
       }
     }
     fetchData()


### PR DESCRIPTION
Currently, we have a blank screen on mobile when we acceed the home page if we have no notes. 

This is because we start rendering an `<AppLinker>` (https://github.com/cozy/cozy-notes/blob/master/src/components/notes/List/EmptyComponent.jsx#L12) with an empty / undefined `href` resulting of on error since the AppLinker needs an url.

To fix this issue, we assign the default URL to the default hooks value 