### PR TITLE
feat: Force sync when leaving the title

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "cozy-realtime": "^3.2.3",
     "cozy-scripts": "^2.0.2",
     "cozy-sharing": "^1.5.2",
-    "cozy-ui": "^28.12.0",
+    "cozy-ui": "^29.1.0",
     "eslint-config-cozy-app": "^1.3.3",
     "lodash": "^4.17.15",
     "react": "~16.8.1",

--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -4,11 +4,13 @@ import { Editor, WithEditorActions } from '@atlaskit/editor-core'
 
 import { MainTitle } from 'cozy-ui/react/Text'
 import Textarea from 'cozy-ui/react/Textarea'
+import { translate } from 'cozy-ui/react/I18n'
+import useEventListener from 'cozy-ui/react/hooks/useEventListener'
 
 import editorConfig from 'components/notes/editor_config'
 import HeaderMenu from 'components/header_menu'
-import { translate } from 'cozy-ui/react/I18n'
 import styles from 'components/notes/editor-view.styl'
+
 function updateTextareaHeight(target) {
   target.style.height = `${target.scrollHeight}px`
 }
@@ -17,6 +19,7 @@ function EditorView(props) {
   const {
     defaultValue,
     onTitleChange,
+    onTitleBlur,
     onContentChange,
     defaultTitle,
     title,
@@ -38,6 +41,8 @@ function EditorView(props) {
   )
 
   useEffect(() => updateTextareaHeight(titleEl.current), [])
+
+  useEventListener(titleEl.current, 'blur', onTitleBlur)
 
   return (
     <article className={styles['note-article']}>

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -198,11 +198,14 @@ const Editor = translate()(
     useEffect(() => forceSync, [docId, doc])
     // Sync on unload will probably be stopped by the browser,
     // as most async code on unload, but let's try anyway
-    const emergencySync = useCallback(function() {
-      if (doc && docId) {
-        serviceClient.sync(docId) // force a server sync
-      }
-    }, [])
+    const emergencySync = useCallback(
+      function() {
+        if (doc && docId) {
+          serviceClient.sync(docId) // force a server sync
+        }
+      },
+      [doc, docId]
+    )
     useEventListener(window, 'unload', emergencySync)
 
     // rendering
@@ -212,6 +215,7 @@ const Editor = translate()(
       return (
         <EditorView
           onTitleChange={onLocalTitleChange}
+          onTitleBlur={emergencySync}
           onContentChange={onContentChange}
           collabProvider={collabProvider}
           defaultTitle={t('Notes.Editor.title_placeholder')}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5153,10 +5153,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@^28.12.0:
-  version "28.12.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-28.12.0.tgz#182d9c16330ef3096ecfdd4f86100140ac2d605b"
-  integrity sha512-+PxXzNy8+lm8L3hILUMYGVGPH/AQFEEPLs6QKhaeDPRzVJHFekvCk40phDwYW4/fVEyPLXx7844zrMLUZFxuMQ==
+cozy-ui@^29.1.0:
+  version "29.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-29.1.0.tgz#fdc90e92bf0b4499e8c1c57c25373cf0641b70ba"
+  integrity sha512-sftVEHXCECzMGSKHwxN+2ai2SZP0sE2Os6mFVW0hcBnTxvMflv0pImspxWDw3jcEVc2jrGfuiA/iIKIOOEkYiw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"


### PR DESCRIPTION
Force a sync on the underlying io.cozy.file
when the user leave the title field.
This will force the io.cozy.file to update its
filename with the lastest title.
