### PR TITLE
refactor: Simplify <Editor> with hooks

### DIFF
--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -15,17 +15,19 @@ function updateTextareaHeight(target) {
   target.style.height = `${target.scrollHeight}px`
 }
 
+const nullCallback = () => {}
+
 function EditorView(props) {
   const {
     defaultValue,
     onTitleChange,
     onTitleBlur,
-    onContentChange,
     defaultTitle,
     title,
     collabProvider,
     leftComponent,
     rightComponent,
+    onContentChange,
     t
   } = props
 
@@ -55,7 +57,7 @@ function EditorView(props) {
       <section className="note-editor-container">
         <Editor
           collabEdit={collabProvider}
-          onChange={onContentChange}
+          onChange={onContentChange || nullCallback}
           defaultValue={defaultValue}
           {...editorConfig}
           appearance="full-page"

--- a/src/components/notes/sharing.jsx
+++ b/src/components/notes/sharing.jsx
@@ -36,6 +36,7 @@ export default withClient(function SharingWidget(props) {
           )
           setParent(parent.data)
         } catch (e) {
+          // eslint-disable-next-line no-console
           console.warn(
             `Request failed when try to fetch the parent ${
               file.attributes.dir_id
@@ -53,13 +54,13 @@ export default withClient(function SharingWidget(props) {
   const [showModal, setShowModal] = useState(false)
   const onClick = useCallback(() => setShowModal(!showModal), [])
   const onClose = useCallback(() => setShowModal(false), [])
-  const docId = file.id
+  const noteId = file.id
   return (
     (parent && (
       <LocalizedSharingProvider doctype={file.type} documentType="Notes">
         <ShareButton
           theme="primary"
-          docId={docId}
+          docId={noteId}
           onClick={onClick}
           label=""
           extension="narrow"

--- a/src/hooks/useCollabProvider.js
+++ b/src/hooks/useCollabProvider.js
@@ -1,0 +1,30 @@
+import { useMemo } from 'react'
+import CollabProvider from 'lib/collab/provider'
+
+function useCollabProvider({ docVersion, noteId, serviceClient }) {
+  return useMemo(
+    () => {
+      if (serviceClient && docVersion !== undefined) {
+        const provider = new CollabProvider(
+          { version: docVersion, noteId },
+          serviceClient
+        )
+        // The following object is defined in an Atlassian API.
+        // `provider` expects a Promise, even if we wouldn't
+        //  need it ourselves.
+        return {
+          useNativePlugin: true,
+          provider: Promise.resolve(provider),
+          inviteToEditHandler: () => undefined,
+          isInviteToEditButtonSelected: false,
+          userId: serviceClient.getSessionId()
+        }
+      } else {
+        return null
+      }
+    },
+    [noteId, docVersion, serviceClient]
+  )
+}
+
+export default useCollabProvider

--- a/src/hooks/useFetchNotesByIds.jsx
+++ b/src/hooks/useFetchNotesByIds.jsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from 'react'
 import cloneDeep from 'lodash/cloneDeep'
 import get from 'lodash/get'
+
 const useFetchNotesByIds = client => {
   const [notes, setNotes] = useState([])
   const [fetchStatus, setFetchStatus] = useState('loading')
+
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -33,6 +35,7 @@ const useFetchNotesByIds = client => {
         setFetchStatus('loaded')
       } catch (error) {
         setFetchStatus('errored')
+        // eslint-disable-next-line no-console
         console.log({ error })
       }
     }

--- a/src/hooks/useForceSync.js
+++ b/src/hooks/useForceSync.js
@@ -1,0 +1,35 @@
+import { useCallback } from 'react'
+
+function useForceSync({ doc, serviceClient, collabProvider }) {
+  const noteId = doc && doc.file.id
+
+  // Be sure to save everything before leaving
+  // and force sync with the io.cozy.file
+  const forceSync = useCallback(
+    async function forceSync() {
+      if (doc && collabProvider && serviceClient) {
+        // wait for every event to finish
+        const provider = await collabProvider.provider
+        await provider.channel.ensureEmptyQueue()
+        // then force a server sync
+        await serviceClient.sync(noteId)
+      }
+    },
+    [doc, collabProvider]
+  )
+
+  // Sync on unload will probably be stopped by the browser,
+  // as most async code on unload, but let's try anyway
+  const emergencySync = useCallback(
+    function() {
+      if (noteId && serviceClient) {
+        serviceClient.sync(noteId) // force a server sync
+      }
+    },
+    [noteId, serviceClient]
+  )
+
+  return { forceSync, emergencySync }
+}
+
+export default useForceSync

--- a/src/hooks/useNote.js
+++ b/src/hooks/useNote.js
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react'
+
+function useNote({ serviceClient, noteId }) {
+  // `docId` is the id of the note for which we have a state.
+  // `noteId` is the id of the requested note.
+  const [docId, setDocId] = useState(noteId)
+  const [loading, setLoading] = useState(true)
+  const [doc, setDoc] = useState(undefined)
+  const [title, setTitle] = useState(undefined)
+
+  useEffect(
+    () => {
+      async function loadNote() {
+        try {
+          if (!loading) setLoading(true)
+          const doc = await serviceClient.getDoc(docId)
+          setTitle(doc.title || '')
+          setDoc(doc)
+        } catch (e) {
+          setTitle(false)
+          setDoc(false)
+          // eslint-disable-next-line no-console
+          console.warn(`Could not load note ${docId}`)
+        }
+        setLoading(false)
+      }
+
+      if (docId !== noteId) {
+        // reload if ever noteId changes
+        setLoading(true)
+        setTitle(undefined)
+        setDoc(undefined)
+        setDocId(noteId)
+      } else if (serviceClient) {
+        // load the note if needed
+        if (!doc || doc.file.id != docId) loadNote()
+      }
+    },
+    [noteId, docId, setDocId, setLoading, serviceClient, setDoc, setTitle]
+  )
+
+  if (docId == noteId) return { loading, title, doc, setTitle }
+  else return { loading: true, title: undefined, doc: undefined, setTitle }
+}
+
+export default useNote

--- a/src/hooks/useNote.js
+++ b/src/hooks/useNote.js
@@ -33,13 +33,13 @@ function useNote({ serviceClient, noteId }) {
         setDocId(noteId)
       } else if (serviceClient) {
         // load the note if needed
-        if (!doc || doc.file.id != docId) loadNote()
+        if (!doc || doc.file.id !== docId) loadNote()
       }
     },
     [noteId, docId, setDocId, setLoading, serviceClient, setDoc, setTitle]
   )
 
-  if (docId == noteId) return { loading, title, doc, setTitle }
+  if (docId === noteId) return { loading, title, doc, setTitle }
   else return { loading: true, title: undefined, doc: undefined, setTitle }
 }
 

--- a/src/hooks/useReturnUrl.js
+++ b/src/hooks/useReturnUrl.js
@@ -1,0 +1,24 @@
+import { useMemo, useContext } from 'react'
+import IsPublicContext from 'components/IsPublicContext'
+import { getParentFolderLink } from 'lib/utils.js'
+
+function useReturnUrl({ returnUrl, cozyClient, doc }) {
+  const isPublic = useContext(IsPublicContext)
+
+  return useMemo(
+    () => {
+      if (returnUrl !== undefined) {
+        return returnUrl
+      } else if (doc) {
+        return getParentFolderLink(cozyClient, doc.file)
+      } else if (!isPublic) {
+        return '/'
+      } else {
+        return undefined
+      }
+    },
+    [returnUrl, doc, isPublic]
+  )
+}
+
+export default useReturnUrl

--- a/src/hooks/useServiceClient.js
+++ b/src/hooks/useServiceClient.js
@@ -1,0 +1,13 @@
+import { useMemo } from 'react'
+import ServiceClient from 'lib/collab/stack-client'
+
+function useServiceClient({ userId, userName, cozyClient }) {
+  return useMemo(
+    () => {
+      return new ServiceClient({ userId, userName, cozyClient })
+    },
+    [userId, userName]
+  )
+}
+
+export default useServiceClient

--- a/src/hooks/useTitleChanges.js
+++ b/src/hooks/useTitleChanges.js
@@ -1,0 +1,42 @@
+import { useMemo, useEffect, useCallback } from 'react'
+import { getAppFullName } from 'lib/utils.js'
+
+function useTitleChanges({ noteId, title, setTitle, serviceClient }) {
+  // Title change because of a local change from the editor
+  const onLocalTitleChange = useCallback(
+    serviceClient
+      ? e => {
+          const modifiedTitle = e.target.value
+          if (title != modifiedTitle) {
+            setTitle(modifiedTitle)
+            serviceClient.setTitle(noteId, modifiedTitle)
+          }
+        }
+      : () => {},
+    [noteId, title, setTitle, serviceClient]
+  )
+  // Title change because of a remote change from the stack
+  useEffect(
+    () => {
+      serviceClient &&
+        serviceClient.onTitleUpdated(noteId, modifiedTitle => {
+          if (title != modifiedTitle) {
+            setTitle(modifiedTitle)
+          }
+        })
+    },
+    [title, setTitle, serviceClient]
+  )
+  // whatever the change is, keep the tab title updated
+  const appFullName = useMemo(getAppFullName, [])
+  useEffect(
+    () => {
+      document.title =
+        title && title != '' ? `${appFullName} - ${title}` : appFullName
+    },
+    [title]
+  )
+  return { onLocalTitleChange }
+}
+
+export default useTitleChanges

--- a/src/hooks/useUser.js
+++ b/src/hooks/useUser.js
@@ -1,0 +1,14 @@
+import { useMemo } from 'react'
+
+import { getShortNameFromClient } from 'lib/utils.js'
+
+function useUser({ userName: providedUserName, cozyClient }) {
+  const userName = useMemo(
+    () => providedUserName || getShortNameFromClient(cozyClient),
+    [providedUserName]
+  )
+  const userId = userName
+  return { userId, userName }
+}
+
+export default useUser

--- a/src/lib/collab/channel.js
+++ b/src/lib/collab/channel.js
@@ -169,8 +169,8 @@ export class Channel {
     if (steps.length === 0) return
 
     try {
-      const { docId } = this.config
-      const response = await this.service.pushSteps(docId, version, steps)
+      const { noteId } = this.config
+      const response = await this.service.pushSteps(noteId, version, steps)
       this.rebaseStepsInQueue()
       this.resetBackoff()
       this.isSending = false
@@ -196,12 +196,12 @@ export class Channel {
    * Connect to pubsub to start receiving events
    */
   async connect(version, doc) {
-    const { docId } = this.config
-    this.service.join(docId)
-    this.service.onStepsCreated(docId, data => {
+    const { noteId } = this.config
+    this.service.join(noteId)
+    this.service.onStepsCreated(noteId, data => {
       this.emit('data', { version: data.version, steps: [data] })
     })
-    this.service.onTelepointerUpdated(docId, payload => {
+    this.service.onTelepointerUpdated(noteId, payload => {
       this.emit('telepointer', payload)
     })
     this.emit('connected', {
@@ -214,16 +214,16 @@ export class Channel {
    * Get steps from version x to latest
    */
   async getSteps(version) {
-    const { docId } = this.config
-    return await this.service.getSteps(docId, version)
+    const { noteId } = this.config
+    return await this.service.getSteps(noteId, version)
   }
 
   /**
    * Send telepointer
    */
   async sendTelepointer(data) {
-    const { docId } = this.config
-    return await this.service.pushTelepointer(docId, data)
+    const { noteId } = this.config
+    return await this.service.pushTelepointer(noteId, data)
   }
 
   /**

--- a/src/lib/collab/channel.spec.js
+++ b/src/lib/collab/channel.spec.js
@@ -5,8 +5,8 @@ jest.mock('prosemirror-collab', () => {
   return { getVersion: jest.fn(), sendableSteps: jest.fn() }
 })
 
-const docId = 'myDocId'
-const config = { docId }
+const noteId = 'myDocId'
+const config = { noteId }
 const service = {
   pushSteps: jest.fn(),
   onStepsCreated: jest.fn(),
@@ -370,13 +370,13 @@ describe('Channel', () => {
           await new Promise(resolve => window.setTimeout(resolve, 500))
           expect(service.pushSteps).toHaveBeenNthCalledWith(
             1,
-            docId,
+            noteId,
             firstVersion,
             steps.localSteps.steps
           )
           expect(service.pushSteps).toHaveBeenNthCalledWith(
             2,
-            docId,
+            noteId,
             lastVersion,
             lastSteps.steps
           )
@@ -400,7 +400,7 @@ describe('Channel', () => {
         version,
         doc
       )
-      expect(service.join).toHaveBeenCalledWith(docId)
+      expect(service.join).toHaveBeenCalledWith(noteId)
     })
 
     it('emits for new steps from the server', async done => {

--- a/src/lib/collab/channel.spec.js
+++ b/src/lib/collab/channel.spec.js
@@ -5,7 +5,7 @@ jest.mock('prosemirror-collab', () => {
   return { getVersion: jest.fn(), sendableSteps: jest.fn() }
 })
 
-const noteId = 'myDocId'
+const noteId = 'myNoteId'
 const config = { noteId }
 const service = {
   pushSteps: jest.fn(),

--- a/src/lib/collab/provider.spec.js
+++ b/src/lib/collab/provider.spec.js
@@ -6,7 +6,7 @@ jest.mock('prosemirror-collab', () => {
   return { getVersion: jest.fn(), sendableSteps: jest.fn() }
 })
 
-const docId = 'myDocId'
+const noteId = 'myDocId'
 const version = 96
 const userId = 'myuser'
 const sessionId = `${userId}:1425`
@@ -22,7 +22,7 @@ const service = {
   getSessionId: jest.fn(),
   getUserId: jest.fn()
 }
-const config = { docId, version, channel }
+const config = { noteId, version, channel }
 const getState = jest.fn()
 const steps = [{ example: version + 1 }, { example: version + 2 }]
 

--- a/src/lib/collab/stack-client.js
+++ b/src/lib/collab/stack-client.js
@@ -163,7 +163,7 @@ export class ServiceClient {
    */
   async join(noteId) {
     const onRealtimeCreated = function(doc) {
-      if (doc.id == noteId) {
+      if (doc.id === noteId) {
         return this.onRealtimeEvent(doc)
       } else {
         return undefined

--- a/src/lib/collab/stack-client.spec.js
+++ b/src/lib/collab/stack-client.spec.js
@@ -6,7 +6,7 @@ import CozyRealtime from 'cozy-realtime'
 import { createMockClient } from 'cozy-client/dist/mock'
 
 const userId = 'myuser'
-const docId = 'e3a0921e38f9687cd9e8c60a3c04f9d0'
+const noteId = 'e3a0921e38f9687cd9e8c60a3c04f9d0'
 const sessionId = userId + ':1577115994661.661.0.16413785152829485'
 const cozyClient = createMockClient({})
 const realtime = { subscribe: jest.fn() }
@@ -326,7 +326,7 @@ describe('ServiceClient', () => {
     const eventType = 'io.cozy.notes.events'
     const telepointerEvent = 'io.cozy.notes.telepointers'
     const telepointerUpdateDoc = {
-      _id: docId,
+      _id: noteId,
       doctype: telepointerEvent,
       selection: { anchor: 6, head: 6, type: 'textSelection' },
       sessionID: sessionId,
@@ -335,7 +335,7 @@ describe('ServiceClient', () => {
     }
     const stepsEvent = 'io.cozy.notes.steps'
     const stepsUpdateDoc = {
-      _id: docId,
+      _id: noteId,
       _rev: '1-03dc114ca621366c35f9bef06205da53',
       doctype: stepsEvent,
       from: 6,
@@ -349,7 +349,7 @@ describe('ServiceClient', () => {
     const titleEvent = 'io.cozy.notes.documents'
     const newTitle = 'hello my new title'
     const titleUpdateDoc = {
-      _id: docId,
+      _id: noteId,
       doctype: titleEvent,
       sessionID: sessionId,
       title: newTitle
@@ -361,7 +361,7 @@ describe('ServiceClient', () => {
     describe('join', () => {
       it('should subscribe to realtime', async () => {
         const service = new ServiceClient({ userId, cozyClient, realtime })
-        await service.join(docId)
+        await service.join(noteId)
         expect(realtime.subscribe).toHaveBeenCalled()
         expect(realtime.subscribe.mock.calls[0][1]).toBe(eventType)
       })
@@ -377,13 +377,13 @@ describe('ServiceClient', () => {
         })
         const onSteps = jest.fn()
         const service = new ServiceClient({ userId, cozyClient, realtime })
-        await service.join(docId)
-        await service.onStepsCreated(docId, onSteps)
+        await service.join(noteId)
+        await service.onStepsCreated(noteId, onSteps)
         expect(callback).toBeDefined()
         callback(stepsUpdateDoc)
         expect(onSteps).toHaveBeenCalled()
         const data = onSteps.mock.calls[0][0]
-        expect(data._id).toBe(docId)
+        expect(data._id).toBe(noteId)
         expect(data.doctype).toBe(stepsEvent)
       })
     })
@@ -398,13 +398,13 @@ describe('ServiceClient', () => {
         })
         const onTelepointer = jest.fn()
         const service = new ServiceClient({ userId, cozyClient, realtime })
-        await service.join(docId)
-        await service.onTelepointerUpdated(docId, onTelepointer)
+        await service.join(noteId)
+        await service.onTelepointerUpdated(noteId, onTelepointer)
         expect(callback).toBeDefined()
         callback(telepointerUpdateDoc)
         expect(onTelepointer).toHaveBeenCalled()
         const data = onTelepointer.mock.calls[0][0]
-        expect(data._id).toBe(docId)
+        expect(data._id).toBe(noteId)
         expect(data.doctype).toBe(telepointerEvent)
       })
     })
@@ -419,8 +419,8 @@ describe('ServiceClient', () => {
         })
         const onTitle = jest.fn()
         const service = new ServiceClient({ userId, cozyClient, realtime })
-        await service.join(docId)
-        await service.onTitleUpdated(docId, onTitle)
+        await service.join(noteId)
+        await service.onTitleUpdated(noteId, onTitle)
         expect(callback).toBeDefined()
         callback(titleUpdateDoc)
         expect(onTitle).toHaveBeenCalled()
@@ -438,8 +438,8 @@ describe('ServiceClient', () => {
       })
       const onSteps = jest.fn()
       const service = new ServiceClient({ userId, cozyClient, realtime })
-      await service.join(docId)
-      await service.onStepsCreated(docId, onSteps)
+      await service.join(noteId)
+      await service.onStepsCreated(noteId, onSteps)
       expect(callback).toBeDefined()
       callback(stepsUpdateDoc)
       expect(onSteps).toHaveBeenCalled()
@@ -468,13 +468,13 @@ describe('ServiceClient', () => {
     it('should call the stack with title', async () => {
       const title = 'hello my new title'
       const service = new ServiceClient({ userId, cozyClient })
-      await service.setTitle(docId, title)
+      await service.setTitle(noteId, title)
       expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalled()
       const fetchJSON = cozyClient.stackClient.fetchJSON
       const called = fetchJSON.mock.calls.length
       const lastCall = fetchJSON.mock.calls[called - 1]
       expect(lastCall[0]).toBe('PUT')
-      expect(lastCall[1]).toBe(`/notes/${docId}/title`)
+      expect(lastCall[1]).toBe(`/notes/${noteId}/title`)
       expect(lastCall[2].data.type).toBe('io.cozy.notes.documents')
       expect(lastCall[2].data.attributes.title).toBe(title)
     })
@@ -486,7 +486,7 @@ describe('ServiceClient', () => {
     const serverResponse = {
       data: {
         type: 'io.cozy.files',
-        id: docId,
+        id: noteId,
         attributes: {
           type: 'file',
           name: 'zdzadda.cozy-note',
@@ -520,39 +520,39 @@ describe('ServiceClient', () => {
 
     it('should call the stack', async () => {
       const service = new ServiceClient({ userId, cozyClient })
-      await service.getDoc(docId)
+      await service.getDoc(noteId)
       expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalled()
       const fetchJSON = cozyClient.stackClient.fetchJSON
       const called = fetchJSON.mock.calls.length
       const lastCall = fetchJSON.mock.calls[called - 1]
       expect(lastCall[0]).toBe('GET')
-      expect(lastCall[1]).toBe(`/notes/${docId}`)
+      expect(lastCall[1]).toBe(`/notes/${noteId}`)
     })
 
     it('should return the doc content', async () => {
       const service = new ServiceClient({ userId, cozyClient })
-      const { doc } = await service.getDoc(docId)
+      const { doc } = await service.getDoc(noteId)
       expect(doc).toHaveProperty('type', 'doc')
       expect(doc).toHaveProperty('content')
     })
 
     it('should return the version', async () => {
       const service = new ServiceClient({ userId, cozyClient })
-      const { version } = await service.getDoc(docId)
+      const { version } = await service.getDoc(noteId)
       expect(version).toBe(serverVersion)
     })
 
     it('should return the title', async () => {
       const service = new ServiceClient({ userId, cozyClient })
-      const { title } = await service.getDoc(docId)
+      const { title } = await service.getDoc(noteId)
       expect(title).toBe(serverTitle)
     })
 
     it('should return the file document', async () => {
       const service = new ServiceClient({ userId, cozyClient })
-      const { file } = await service.getDoc(docId)
+      const { file } = await service.getDoc(noteId)
       expect(file.type).toBe('io.cozy.files')
-      expect(file.id).toBe(docId)
+      expect(file.id).toBe(noteId)
     })
   })
 
@@ -584,13 +584,13 @@ describe('ServiceClient', () => {
 
     it('should send to the server', async () => {
       const service = new ServiceClient({ userId, cozyClient })
-      await service.pushSteps(docId, localVersion, localSteps)
+      await service.pushSteps(noteId, localVersion, localSteps)
       expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalled()
       const fetchJSON = cozyClient.stackClient.fetchJSON
       const called = fetchJSON.mock.calls.length
       const lastCall = fetchJSON.mock.calls[called - 1]
       expect(lastCall[0]).toBe('PATCH')
-      expect(lastCall[1]).toBe(`/notes/${docId}`)
+      expect(lastCall[1]).toBe(`/notes/${noteId}`)
       expect(lastCall[2].data).toHaveLength(localSteps.length)
       // for conflict resolution
       expect(lastCall[3]).toHaveProperty('headers.if-match', localVersion)
@@ -598,7 +598,7 @@ describe('ServiceClient', () => {
 
     it('should send io.cozy.notes.steps documents', async () => {
       const service = new ServiceClient({ userId, cozyClient })
-      await service.pushSteps(docId, localVersion, localSteps)
+      await service.pushSteps(noteId, localVersion, localSteps)
       expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalled()
       const fetchJSON = cozyClient.stackClient.fetchJSON
       const called = fetchJSON.mock.calls.length
@@ -612,7 +612,7 @@ describe('ServiceClient', () => {
         throw new Error()
       })
       const service = new ServiceClient({ userId, cozyClient })
-      const push = service.pushSteps(docId, localVersion, localSteps)
+      const push = service.pushSteps(noteId, localVersion, localSteps)
       await expect(push).rejects.toBeInstanceOf(Error)
     })
   })
@@ -654,7 +654,7 @@ describe('ServiceClient', () => {
     const remoteDocument = {
       data: {
         type: 'io.cozy.files',
-        id: docId,
+        id: noteId,
         attributes: {
           type: 'file',
           name: 'zdzadda.cozy-note',
@@ -685,19 +685,19 @@ describe('ServiceClient', () => {
     it('should ask the server', async () => {
       cozyClient.stackClient.fetchJSON.mockImplementation(() => ({ data: [] }))
       const service = new ServiceClient({ userId, cozyClient })
-      await service.getSteps(docId, localVersion)
+      await service.getSteps(noteId, localVersion)
       expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalled()
       const fetchJSON = cozyClient.stackClient.fetchJSON
       const called = fetchJSON.mock.calls.length
       const lastCall = fetchJSON.mock.calls[called - 1]
       expect(lastCall[0]).toBe('GET')
-      expect(lastCall[1]).toBe(`/notes/${docId}/steps?Version=${localVersion}`)
+      expect(lastCall[1]).toBe(`/notes/${noteId}/steps?Version=${localVersion}`)
     })
 
     it('should return steps when the server has some', async () => {
       cozyClient.stackClient.fetchJSON.mockImplementation(() => remoteSteps)
       const service = new ServiceClient({ userId, cozyClient })
-      const res = await service.getSteps(docId, localVersion)
+      const res = await service.getSteps(noteId, localVersion)
       expect(res).toHaveProperty('version', remoteVersion)
       expect(res).toHaveProperty('steps')
       expect(res.steps).toHaveLength(2)
@@ -706,7 +706,7 @@ describe('ServiceClient', () => {
     it('should return steps with a `sessionId`', async () => {
       cozyClient.stackClient.fetchJSON.mockImplementation(() => remoteSteps)
       const service = new ServiceClient({ userId, cozyClient })
-      const res = await service.getSteps(docId, localVersion)
+      const res = await service.getSteps(noteId, localVersion)
       expect(res.steps[0]).toHaveProperty(
         'sessionId',
         remoteSteps.data[0].attributes.sessionID
@@ -716,7 +716,7 @@ describe('ServiceClient', () => {
     it('should return current version when there is 0 steps', async () => {
       cozyClient.stackClient.fetchJSON.mockImplementation(() => ({ data: [] }))
       const service = new ServiceClient({ userId, cozyClient })
-      const res = await service.getSteps(docId, localVersion)
+      const res = await service.getSteps(noteId, localVersion)
       expect(res).toHaveProperty('version', localVersion)
       expect(res).toHaveProperty('steps', [])
       expect(res.steps).toHaveLength(0)
@@ -730,7 +730,7 @@ describe('ServiceClient', () => {
         }
       })
       const service = new ServiceClient({ userId, cozyClient })
-      const res = await service.getSteps(docId, localVersion)
+      const res = await service.getSteps(noteId, localVersion)
       expect(res).toHaveProperty('version', remoteVersion)
       expect(res).not.toHaveProperty('steps')
       expect(res).toHaveProperty('doc', serverDoc)
@@ -745,8 +745,8 @@ describe('ServiceClient', () => {
       })
       const callback = jest.fn()
       const service = new ServiceClient({ userId, cozyClient })
-      service.onTitleUpdated(docId, callback)
-      await service.getSteps(docId, localVersion)
+      service.onTitleUpdated(noteId, callback)
+      await service.getSteps(noteId, localVersion)
       expect(callback).toHaveBeenLastCalledWith(remoteTitle)
     })
   })
@@ -765,13 +765,13 @@ describe('ServiceClient', () => {
 
     it('should send data to the server', async () => {
       const service = new ServiceClient({ userId, cozyClient })
-      await service.pushTelepointer(docId, telepointerData)
+      await service.pushTelepointer(noteId, telepointerData)
       expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalled()
       const fetchJSON = cozyClient.stackClient.fetchJSON
       const called = fetchJSON.mock.calls.length
       const lastCall = fetchJSON.mock.calls[called - 1]
       expect(lastCall[0]).toBe('PUT')
-      expect(lastCall[1]).toBe(`/notes/${docId}/telepointer`)
+      expect(lastCall[1]).toBe(`/notes/${noteId}/telepointer`)
       expect(lastCall[2]).toHaveProperty('data.type', telepointerEvent)
       expect(lastCall[2]).toHaveProperty('data.attributes.type', 'telepointer')
     })
@@ -784,10 +784,10 @@ describe('ServiceClient', () => {
 
     it('should call the server', async () => {
       const service = new ServiceClient({ userId, cozyClient })
-      await service.sync(docId)
+      await service.sync(noteId)
       expect(cozyClient.stackClient.fetchJSON).toHaveBeenCalledWith(
         'POST',
-        `/notes/${docId}/sync`
+        `/notes/${noteId}/sync`
       )
     })
   })


### PR DESCRIPTION
Tentative de refactorisation de &lt;Editor>

Objectif de limiter la complexité (je commençais à ne plus forcément voir toutes les interactions) et de permettre plus tard le test de la logique métier (qui me semblait plus que difficile à tester dans la forme monolithique)