### PR TITLE
chore: Bump to 1.5.1

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -4,7 +4,7 @@
   "slug": "notes",
   "icon": "icon.svg",
   "categories": ["cozy"],
-  "version": "1.5.0",
+  "version": "1.5.1",
   "licence": "AGPL-3.0",
   "editor": "Cozy",
   "source": "https://github.com/cozy/cozy-notes.git@build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-notes",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "scripts": {
     "tx": "tx pull --all || true",
     "lint": "yarn lint:js && yarn lint:styles",


### PR DESCRIPTION
1.5.0 was already deployed. Let's deploy 1.5.1 with a bugfix 