### PR TITLE
fix: Refresh token

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@atlaskit/media-editor": "^37.0.3",
     "@atlaskit/smart-card": "^12.6.2",
     "cozy-bar": "^7.7.8",
-    "cozy-client": "^9.3.0",
+    "cozy-client": "^9.8.1",
     "cozy-device-helper": "^1.8.0",
     "cozy-doctypes": "^1.70.0",
     "cozy-realtime": "^3.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4402,6 +4402,11 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+btoa@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
+  integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
+
 buffer-equal@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-0.0.1.tgz#91bc74b11ea405bc916bc6aa908faafa5b4aac4b"
@@ -5255,19 +5260,24 @@ cozy-bar@^7.7.8:
     redux-persist "5.10.0"
     redux-thunk "2.3.0"
 
-cozy-client@^9.3.0:
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-9.3.0.tgz#a7ae1c8b86ed153743411a04d0cd74a20520f192"
-  integrity sha512-0oqRErnUFh5n7rBmjomSC1tNx4F+35D86TlrphXFi494EmSmjKyF0yMnyNVCtA0nB6EaAo2mC1BTEWuUZg8x0A==
+cozy-client@^9.8.1:
+  version "9.8.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-9.8.1.tgz#e83aac74e84c6ac7c2dbb414c77bea8b3b5ea20e"
+  integrity sha512-nyrQX3HIVTBl7PnBW502vpJi1N0SZRXEUvJP23Qq26UkQ98t9asXFENa5EVz2yFMAQOkCZXno3ZP16q232LqGg==
   dependencies:
+    btoa "^1.2.1"
     cozy-device-helper "^1.7.3"
-    cozy-stack-client "^9.2.0"
+    cozy-logger "^1.6.0"
+    cozy-stack-client "^9.8.1"
+    isomorphic-fetch "^2.2.1"
     lodash "^4.17.13"
     microee "^0.0.6"
+    opn "^6.0.0"
     prop-types "^15.6.2"
     react-redux "^5.0.7"
     redux "^3.7.2"
     redux-thunk "^2.3.0"
+    server-destroy "^1.0.1"
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
@@ -5405,10 +5415,10 @@ cozy-sharing@^1.5.2:
     react-autosuggest "^9.4.3"
     react-tooltip "^3.11.1"
 
-cozy-stack-client@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-9.2.0.tgz#3d6a9af9e42f6f2d8fad7fe57e83713a3bcafc77"
-  integrity sha512-ivMjA+EtV7lu6lKzuOIiS00XcTVL6WRbycSmfO7SJrAU12kWp54rlKDS9rMFA2NjCEShjTVdu0intkxYbuimsw==
+cozy-stack-client@^9.8.1:
+  version "9.8.1"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-9.8.1.tgz#807b349d6394f4430e8f5cdfd6c60ca71aaa11d3"
+  integrity sha512-2Fo1Y9nd2zqsITRQDm+Ps01Fwrfd22OSveRkZqm8ugWQHjvRfccTMFx7Dnji2ZWnDvZv6GdKX271eHfojIOllg==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
@@ -8937,7 +8947,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isomorphic-fetch@^2.1.1:
+isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
@@ -11018,6 +11028,13 @@ opn@^5.1.0, opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
   integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
+  dependencies:
+    is-wsl "^1.1.0"
+
+opn@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/opn/-/opn-6.0.0.tgz#3c5b0db676d5f97da1233d1ed42d182bc5a27d2d"
+  integrity sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==
   dependencies:
     is-wsl "^1.1.0"
 
@@ -13817,6 +13834,11 @@ serve-static@1.14.1, serve-static@^1.12.4:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.17.1"
+
+server-destroy@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/server-destroy/-/server-destroy-1.0.1.tgz#f13bf928e42b9c3e79383e61cc3998b5d14e6cdd"
+  integrity sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=
 
 set-blocking@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Previously, saving requests were failing indefinitely when
the stack token had expired. An update of cozy-client
fixes that.

See https://github.com/cozy/cozy-client/pull/618