### PR TITLE
feat: Display time for updated_at

### DIFF
--- a/src/components/notes/List/NoteRow.jsx
+++ b/src/components/notes/List/NoteRow.jsx
@@ -10,7 +10,7 @@ import styles from 'components/notes/List/list.styl'
 import { generateReturnUrlToNotesIndex } from 'lib/utils'
 import NoteIcon from 'assets/icons/icon-note-32.svg'
 
-const NoteRow = ({ note, f, breakpoints: { isMobile } }) => {
+const NoteRow = ({ note, f, t, breakpoints: { isMobile } }) => {
   const { filename, extension } = CozyFile.splitFilename(note)
   return (
     <TableRow
@@ -31,7 +31,10 @@ const NoteRow = ({ note, f, breakpoints: { isMobile } }) => {
       {!isMobile && (
         <>
           <TableCell className={styles.tableCell}>
-            {f(note.updated_at, 'DD MMMM')}
+            {t('Notes.List.at', {
+              date: f(note.updated_at, 'DD MMMM'),
+              time: f(note.updated_at, 'hh:ss')
+            })}
           </TableCell>
           <TableCell className={styles.tableCell}>—</TableCell>
           <TableCell className={styles.tableCell}>—</TableCell>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -15,7 +15,8 @@
       "name": "Name",
       "updated_at": "Updated at",
       "location": "Location",
-      "sharings": "Sharings"
+      "sharings": "Sharings",
+      "at": "%{date} at %{time}"
     },
     "Empty": {
       "welcome": "Welcome on Cozy Notes",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -15,7 +15,8 @@
       "name": "Nom",
       "updated_at": "Mise à jour",
       "location": "Emplacement",
-      "sharings": "Partage"
+      "sharings": "Partage",
+      "at": "%{date} à %{time}"
     },
     "Empty": {
       "welcome": "Bienvenue sur Cozy Notes",


### PR DESCRIPTION
ATM we only displayed the date of the last update. It can be useful to also have the time. 

This PR adds that. 

<img width="197" alt="Capture d’écran 2020-01-23 à 11 12 59" src="https://user-images.githubusercontent.com/1107936/72976676-544dcc80-3dd3-11ea-9afd-9802893b1147.png">


Just a WIP. Waiting to have the feedback from @joel-costa ;) 