### PR TITLE
feat: Confirmation on exit when changing page

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cozy-realtime": "^3.2.3",
     "cozy-scripts": "^2.0.2",
     "cozy-sharing": "^1.5.2",
-    "cozy-ui": "^29.8.0",
+    "cozy-ui": "^30.0.0",
     "eslint-config-cozy-app": "^1.3.3",
     "lodash": "^4.17.15",
     "react": "^16.12.0",

--- a/src/components/notes/back_from_editing.jsx
+++ b/src/components/notes/back_from_editing.jsx
@@ -1,12 +1,53 @@
 import React, { useContext } from 'react'
-import { Link } from 'react-router-dom'
 import { Button, ButtonLink } from 'cozy-ui/react/Button'
 import IsPublicContext from 'components/IsPublicContext'
 import AppLinker from 'cozy-ui/react/AppLinker'
 import { getFolderLink, getParentFolderId } from 'lib/utils'
 
-export default function BackFromEditing({ returnUrl, file }) {
+/**
+ * Simple fake event to detect if the handler
+ * tries to prevent the default action
+ */
+class FakeEvent {
+  preventDefault() {
+    this.prevented = true
+  }
+}
+
+/**
+ * Create a click handler for a link or button
+ *
+ * Always call requestToLeave, with a function
+ * that should mimic the original behaviour (onClick +  href)
+ * @param {function} requestToLeave - as  in useConfirmExit in cozy-ui
+ * @param {string} href - URL to go to
+ * @param {function} onClick -  regular onClick handler for the button or link
+ */
+function createOnClick(requestToLeave, href, onClick) {
+  const go = () => {
+    const ev = new FakeEvent()
+    if (onClick) onClick(ev)
+    if (!ev.prevented) document.location = href
+  }
+  return function(ev) {
+    ev.preventDefault()
+    requestToLeave(go)
+  }
+}
+
+/**
+ * React component, draws a button to go back, outside of the editor
+ *
+ * Default is going back to the root of the app if in a private view
+ * or do nothing if in a public view
+ * @param {string|null} returnUrl - URL to go back to
+ * @param {object|null} file - io.cozy.file object to generate a folder link
+ * @param {function|null} requestToLeave - function, if present, it should
+ * wrap any regular action that should have taken place when clicking the button
+ */
+export default function BackFromEditing({ returnUrl, file, requestToLeave }) {
   const isPublic = useContext(IsPublicContext)
+
   if (returnUrl) {
     const nativePath = getFolderLink(getParentFolderId(file))
     return (
@@ -15,7 +56,7 @@ export default function BackFromEditing({ returnUrl, file }) {
           return (
             <ButtonLink
               icon="previous"
-              onClick={onClick}
+              onClick={createOnClick(requestToLeave, href, onClick)}
               href={href}
               className="sto-app-back"
               subtle
@@ -25,11 +66,12 @@ export default function BackFromEditing({ returnUrl, file }) {
       </AppLinker>
     )
   } else if (!isPublic) {
+    const href = '#/'
     return (
       <Button
         icon="previous"
-        tag={Link}
-        to="/"
+        href={href}
+        onClick={createOnClick(requestToLeave, href)}
         className="sto-app-back"
         subtle
       />

--- a/src/hooks/useCollaborationState.js
+++ b/src/hooks/useCollaborationState.js
@@ -3,11 +3,13 @@ import { useState, useEffect, useRef } from 'react'
 let iterations = 0
 
 /**
- * The complete Triforce, or one or more components of the Triforce.
+ * Return value of  useCollaborationState
  * @typedef {CollabState}
  * @property {boolean} isDirty - Is there something local still waiting to be sync?
- * @property {Date} dirtySinc - Date of the older object waiting to be sync
+ * @property {Date} dirtySince - Date of the older object waiting to be sync, falsy when in sync
  * @property {Date} lastSave - Date of the earlier object that has been correctly sync
+ * @property {React.Reference} dirtyRef - React reference, which holds the most up to date
+ * value of dirtySince in `.current`
  */
 
 /**
@@ -85,7 +87,8 @@ function useCollaborationState(provider) {
   return {
     dirtySince: dirtySince.current,
     lastSave: lastSave.current,
-    isDirty: !!dirtySince.current
+    isDirty: !!dirtySince.current,
+    dirtyRef: dirtySince
   }
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -8,7 +8,8 @@
     },
     "Editor": {
       "title_placeholder": "Here is your title",
-      "exit_confirmation": "Some changes inside the note have not been saved yet. Do you want to quit and loose these changes?"
+      "exit_confirmation_message": "Some changes inside the note have not been saved yet. Do you want to quit and lose these changes?",
+      "exit_confirmation_title": "Leave this note?"
     },
     "List": {
       "my_notes": "My Notes",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -8,7 +8,8 @@
     },
     "Editor": {
       "title_placeholder": "Ici votre titre",
-      "exit_confirmation": "Des modifications n’ont pas encore encore pu être enregistrées sur cette note. Voulez-vous vraiment quitter et perdre ces modifications ?"
+      "exit_confirmation_message": "Des modifications n’ont pas encore pu être enregistrées sur cette note. Voulez-vous vraiment quitter et perdre ces modifications ?",
+      "exit_confirmation_title": "Quitter cette note ?"
     },
     "List": {
       "my_notes": "Mes Notes",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5630,10 +5630,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@^29.8.0:
-  version "29.8.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-29.8.0.tgz#3d0fc32fd02a2376950e5a22950e29dbbd3d115b"
-  integrity sha512-YTafMAp0S/N35yDEDs4rnMd6THqTou7m4sICUqptfbxJvVAcouYc1X5+wOwh7pEyZWqtwU432G8DTN+0HOooIw==
+cozy-ui@^30.0.0:
+  version "30.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-30.0.0.tgz#42cded71db7203c5368248a1b9baf1a5b313da4d"
+  integrity sha512-da+myTL2qYUyX4GajnD4Ng9WY+X1MWeXJmcCXLcgrvNPDDR3Z4lyawErX6kJUuarveqMjlRKSEtlPjPwZSdJYw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"


### PR DESCRIPTION
Uses the last useConfirmationExit available in https://github.com/cozy/cozy-ui/pull/1366 to also warn about unsaved changes when the user clicks on the button to return to the list of notes.