### PR TITLE
fix: Reword note delete message

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -5,7 +5,7 @@
     },
     "Delete": {
       "delete_note": "Delete",
-      "deleted": "The note has been deleted",
+      "deleted": "The note has been moved to the trash of your Drive",
       "failed": "The note could not be deleted, please try again"
     },
     "EditorView": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -5,7 +5,7 @@
     },
     "Delete": {
       "delete_note": "Supprimer",
-      "deleted": "La note à été supprimée",
+      "deleted": "La note a été placée dans la corbeille de votre Drive",
       "failed": "La note n'a pas pu être supprimée, merci de re-essayer plus tard"
     },
     "EditorView": {


### PR DESCRIPTION
Instead of implementing a full cancel system, we explain that the note is now in the trash (from which it can be restored, even though that is not explicit in the alert message).