### PR TITLE
feat: Public route with share token for a parent folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@atlaskit/smart-card": "^12.6.2",
     "@material-ui/core": "^3.9.3",
     "cozy-bar": "^7.7.8",
-    "cozy-client": "9.10.0",
+    "cozy-client": "10.8.1",
     "cozy-device-helper": "^1.8.0",
     "cozy-doctypes": "^1.70.0",
     "cozy-flags": "2.1.0",

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -2,6 +2,7 @@ import get from 'lodash/get'
 import { generateWebLink } from 'cozy-ui/transpiled/react/AppLinker'
 import { getDataset, getDataOrDefault } from './initFromDom'
 import { schemaOrdered } from 'lib/collab/schema'
+import { models } from 'cozy-client'
 
 import manifest from '../../manifest.webapp'
 
@@ -30,20 +31,49 @@ export const generateReturnUrlToNotesIndex = doc => {
 }
 
 /**
- * Is this permission read only for a note?
- *
- * @param {object} perm - permission node in a io.cozy.permissions document
- * @returns {bool} true if the note should be displayed read-only
+ * Get permissions on io.cozy.files for current context
+ * @private
+ * @param {CozyClient} client
+ * @returns {object}
  */
-function isPermissionReadOnly(perm) {
-  //  PATCH is included by default, and in the ALL shortcut
-  return (
-    perm.verbs &&
-    perm.verbs &&
-    perm.verbs.length > 0 &&
-    !perm.verbs.includes('PATCH') &&
-    !perm.verbs.includes('ALL')
+async function getFilesOwnPermissions(client) {
+  const permissionsData = await client
+    .collection('io.cozy.permissions')
+    .getOwnPermissions()
+  const permissionObject = get(permissionsData, 'data.attributes.permissions')
+  if (!permissionObject) throw `can't get self permissions`
+  const permissions = Object.values(permissionObject)
+  return permissions.filter(perm =>
+    models.permission.isForType(perm, 'io.cozy.files')
   )
+}
+
+/**
+ * Get a file by it's id
+ * @private
+ * @param {CozyClient} client
+ * @param {string} id
+ */
+async function getFile(client, id) {
+  return client
+    .query(client.find('io.cozy.files').getById(id))
+    .then(data => data && data.data)
+}
+
+/**
+ * Checks if the note is read-only or read-write
+ *
+ * @param {CozyClient} client
+ * @param {string} fileId - io.cozy.files id
+ * @returns {bool}
+ */
+export async function fetchIfIsNoteReadOnly(client, fileId) {
+  const document = await getFile(client, fileId)
+  return models.permission.isDocumentReadOnly({
+    document,
+    client,
+    writability: ['PATCH']
+  })
 }
 
 /**
@@ -53,19 +83,29 @@ function isPermissionReadOnly(perm) {
  * @returns {{id, readOnly}} id of the document and the readOnly status
  */
 export async function getSharedDocument(client) {
-  const { data: permissionsData } = await client
-    .collection('io.cozy.permissions')
-    .getOwnPermissions()
-  const permissions = permissionsData.attributes.permissions
-  // permissions contains several named keys, but the one to use depends on the situation. Using the first one is what we want in all known cases.
-  const perm = get(Object.values(permissions), '0')
-  const sharedDocumentId = perm && get(perm, 'values.0')
-  const readOnly = perm && isPermissionReadOnly(perm)
-  return { id: sharedDocumentId, readOnly }
-}
+  const permissions = (await getFilesOwnPermissions(client)).filter(
+    p =>
+      models.permission.isForType(p, 'io.cozy.files') &&
+      p.values &&
+      p.values.length > 0
+  )
 
-export function getParentFolderId(file) {
-  return file.relationships.parent.data.id
+  if (permissions.length < 1) {
+    throw new Error(
+      'No individual io.cozy.files permissions in current context'
+    )
+  } else if (permissions.length > 1 || permissions[0].values.length > 1) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `There are more than one permission for a file in current context. Let's take the first one, but it may not be the one you expect`
+    )
+  }
+  const perm = permissions[0]
+  const sharedDocumentId = perm.values[0]
+  const readOnly = models.permission.isReadOnly(perm, {
+    writability: ['PATCH']
+  })
+  return { id: sharedDocumentId, readOnly }
 }
 
 export function getFolderLink(id) {
@@ -89,7 +129,7 @@ export function getDriveLink(client, id = null) {
 }
 
 export function getParentFolderLink(client, file) {
-  return getDriveLink(client, getParentFolderId(file))
+  return getDriveLink(client, models.file.getParentFolderId(file))
 }
 
 export function getAppFullName() {

--- a/src/lib/utils.spec.js
+++ b/src/lib/utils.spec.js
@@ -1,39 +1,79 @@
-import { getSharedDocument, getFolderLink } from './utils'
+import {
+  getSharedDocument,
+  fetchIfIsNoteReadOnly,
+  getFolderLink
+} from './utils'
 
-describe('getSharedDocument', () => {
-  function setupClient(verbs = []) {
-    return {
-      collection: () => ({
-        getOwnPermissions: async () => ({
+function setupClient(verbs = [], ids = ['first', 'other']) {
+  return {
+    find: doctype => ({
+      getById: id => {
+        const parents = {
+          'first-ggchild': 'first-gchild',
+          'first-gchild': 'first-child',
+          'first-child': 'first'
+        }
+        return {
           data: {
-            id: '9385e37389cb9f71a230168f245df2f8',
-            _id: '9385e37389cb9f71a230168f245df2f8',
-            _type: 'io.cozy.permissions',
-            type: 'io.cozy.permissions',
+            _id: id,
+            id: id,
+            _type: doctype,
+            type: doctype,
             attributes: {
-              type: 'share',
-              source_id: 'io.cozy.apps/notes',
-              permissions: {
-                files: {
-                  type: 'io.cozy.files',
-                  verbs: verbs,
-                  values: ['first', 'other']
-                },
-                album: {
-                  type: 'io.cozy.photo.albums',
-                  verbs: verbs,
-                  values: ['third']
+              dir_id: parents[id]
+            },
+            relationships: {
+              parent: {
+                data: {
+                  id: parents[id],
+                  type: doctype
                 }
-              },
-              shortcodes: {
-                email: 'k7oMbB11jKFR'
               }
             }
           }
-        })
+        }
+      }
+    }),
+    query: async data => data,
+    collection: () => ({
+      getOwnPermissions: async () => ({
+        data: {
+          id: '9385e37389cb9f71a230168f245df2f8',
+          _id: '9385e37389cb9f71a230168f245df2f8',
+          _type: 'io.cozy.permissions',
+          type: 'io.cozy.permissions',
+          attributes: {
+            type: 'share',
+            source_id: 'io.cozy.apps/notes',
+            permissions: {
+              files: {
+                type: 'io.cozy.files',
+                verbs: verbs,
+                values: ids
+              },
+              album: {
+                type: 'io.cozy.photo.albums',
+                verbs: verbs,
+                values: ['third']
+              }
+            },
+            shortcodes: {
+              email: 'k7oMbB11jKFR'
+            }
+          }
+        }
       })
-    }
+    })
   }
+}
+
+describe('getSharedDocument', () => {
+  beforeAll(() => {
+    jest.spyOn(global.console, 'warn').mockImplementation(() => {})
+  })
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
 
   it('fetches the first document in the permission list', async () => {
     const client = setupClient()
@@ -62,6 +102,29 @@ describe('getSharedDocument', () => {
       const client = setupClient(['GET'])
       const { readOnly } = await getSharedDocument(client)
       expect(readOnly).toBeTruthy()
+    })
+  })
+})
+
+describe('fetchIfIsNoteReadOnly', () => {
+  ;[
+    ['only one individual file permission', ['only'], 'only'],
+    ['a permission for this file', ['first', 'second'], 'first'],
+    ['a permission for an ancestor', ['first', 'second'], 'first-ggchild']
+  ].forEach(data => {
+    describe(`when there is ${data[0]}`, () => {
+      describe('when we have a PATCH permission', () => {
+        it('should return read-write', async () => {
+          const client = setupClient(['GET', 'PATCH'], data[1])
+          expect(fetchIfIsNoteReadOnly(client, data[2])).resolves.toBeFalsy()
+        })
+      })
+      describe('when we only have a GET permission', () => {
+        it('should return read-only', async () => {
+          const client = setupClient(['GET'], data[1])
+          expect(fetchIfIsNoteReadOnly(client, data[2])).resolves.toBeTruthy()
+        })
+      })
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5370,19 +5370,19 @@ cozy-bar@^7.7.8:
     redux-persist "5.10.0"
     redux-thunk "2.3.0"
 
-cozy-client@9.10.0:
-  version "9.10.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-9.10.0.tgz#4519d24a8ccc4eb99880099ff4dd88cf9547b755"
-  integrity sha512-g2dn1mJ/HKks+nbJrDMS165OzAvOITq4IKRNovi/9dUWO8rLD0eyzlowWL5OsCADwyFrQb7pyguQdws/aFdc7Q==
+cozy-client@10.8.1:
+  version "10.8.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-10.8.1.tgz#e9887cae8717baf837bc59f8fc0a514cbb01ca82"
+  integrity sha512-Bc2SYiHvfYTkklLaMvWnUuTdkkMAo6wtQ8iK3MbW6zb7tVIFMsYno7fihsnRUg9AMX8Swl6FmP8YZSIEqs3Xvw==
   dependencies:
     btoa "^1.2.1"
     cozy-device-helper "^1.7.3"
     cozy-logger "^1.6.0"
-    cozy-stack-client "^9.10.0"
+    cozy-stack-client "^10.7.0"
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.13"
     microee "^0.0.6"
-    opn "^6.0.0"
+    open "^7.0.2"
     prop-types "^15.6.2"
     react-redux "^5.0.7"
     redux "^3.7.2"
@@ -5532,10 +5532,10 @@ cozy-sharing@^1.5.2:
     react-autosuggest "^9.4.3"
     react-tooltip "^3.11.1"
 
-cozy-stack-client@^9.10.0:
-  version "9.10.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-9.10.0.tgz#5b6bc4e84c7914aabc73f30fd5599b6729aaa2d1"
-  integrity sha512-Ku+IX+E2c6ARHcFjWc5cpwiwr0Ixj8NM/vsRnKkEgW8DmhQa6vaGbXc3GVpx9qfPiA93ymiIYoA9SjGVa+tJAQ==
+cozy-stack-client@^10.7.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-10.7.0.tgz#2f9a886af423abe9111d6c1524104c29d2ed517f"
+  integrity sha512-O2z9sFwDhcbn/rZJr0f2BL3CAc2L37QMzmIlQXY/70x/SqkSd+zyFhgwfYImqlwYsByf6Mo6qwtpwv5goRj9Ig==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
@@ -8935,6 +8935,11 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
+is-docker@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
+  integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -9195,6 +9200,11 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+is-wsl@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
+  integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
 
 isarray@0.0.1:
   version "0.0.1"
@@ -11375,6 +11385,14 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+open@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.0.2.tgz#fb3681f11f157f2361d2392307548ca1792960e8"
+  integrity sha512-70E/pFTPr7nZ9nLDPNTcj3IVqnNvKuP4VsBmoKV9YGTnChe0mlS3C4qM7qKarhZ8rGaHKLfo+vBTHXDp6ZSyLQ==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 opener@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
@@ -11384,13 +11402,6 @@ opn@^5.1.0, opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
   integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
-  dependencies:
-    is-wsl "^1.1.0"
-
-opn@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-6.0.0.tgz#3c5b0db676d5f97da1233d1ed42d182bc5a27d2d"
-  integrity sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==
   dependencies:
     is-wsl "^1.1.0"
 


### PR DESCRIPTION
This changes add the ability to give an the file id as parameter
in the public route of a share. This is needed when the sharecode
is about multiple files or about a note.

This changes also take into account if the permission of the share code
states the share is read only or not.
