### PR TITLE
fix: Goes back to root dir

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -69,7 +69,7 @@ export function getParentFolderId(file) {
 }
 
 export function getFolderLink(id) {
-  return `/folder/${id.replace(/-/g, '')}`
+  return `/folder/${id}`
 }
 
 export function getDriveLink(client, id = null) {

--- a/src/lib/utils.spec.js
+++ b/src/lib/utils.spec.js
@@ -1,4 +1,4 @@
-import { getSharedDocument } from './utils'
+import { getSharedDocument, getFolderLink } from './utils'
 
 describe('getSharedDocument', () => {
   function setupClient(verbs = []) {
@@ -62,6 +62,15 @@ describe('getSharedDocument', () => {
       const client = setupClient(['GET'])
       const { readOnly } = await getSharedDocument(client)
       expect(readOnly).toBeTruthy()
+    })
+  })
+})
+
+describe('getFolderLink', () => {
+  describe('when root-dir', () => {
+    it('should be #/folder/io.cozy.files.root-dir', () => {
+      const id = 'io.cozy.files.root-dir'
+      expect(getFolderLink(id)).toEqual('/folder/io.cozy.files.root-dir')
     })
   })
 })


### PR DESCRIPTION
When the note is  present in the root dir, the link going back if invalid and send to an error page.
This change fixes that.

Note: I do not know nor understand why we were stripping "-"  in the folder ids. It's probably better to wait for @Crash-- approval before merging this PR