### PR TITLE
feat: Allows a user provided username

### DIFF
--- a/src/hooks/useUser.js
+++ b/src/hooks/useUser.js
@@ -1,10 +1,13 @@
 import { useMemo } from 'react'
 
-import { getShortNameFromClient } from 'lib/utils.js'
+import { getShortNameFromClient, getUserNameFromUrl } from 'lib/utils.js'
 
 function useUser({ userName: providedUserName, cozyClient }) {
   const userName = useMemo(
-    () => providedUserName || getShortNameFromClient(cozyClient),
+    () =>
+      providedUserName ||
+      getUserNameFromUrl() ||
+      getShortNameFromClient(cozyClient),
     [cozyClient, providedUserName]
   )
   const userId = userName

--- a/src/hooks/useUser.spec.js
+++ b/src/hooks/useUser.spec.js
@@ -1,0 +1,17 @@
+import useUser from './useUser'
+
+import { renderHook } from '@testing-library/react-hooks'
+
+describe('useUser', () => {
+  describe('with an explicit username in the url', () => {
+    it('should return  this username', () => {
+      window.history.pushState(
+        {},
+        'Test Title',
+        '/test.html?username=hello+world'
+      )
+      const { result } = renderHook(() => useUser({}))
+      expect(result.current.userName).toEqual('hello world')
+    })
+  })
+})

--- a/src/lib/collab/participant.js
+++ b/src/lib/collab/participant.js
@@ -2,11 +2,6 @@ export const getParticipant = ({ userId, sessionId }) => ({
   userId: sessionId,
   sessionId: sessionId || userId,
   name: userId,
-  avatar: `https://api.adorable.io/avatars/80/${userId.replace(
-    /[^a-zA-Z0-9]/g,
-    ''
-  )}.png`,
-  email: `${userId
-    .replace(/\s+/g, '.')
-    .replace(/[^a-zA-Z0-9.]/g, '')}.toLocaleLowerCase()}@mycozy.cloud`
+  avatar: null,
+  email: null
 })

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -153,3 +153,17 @@ export function createNoteDocument(client) {
     }
   })
 }
+
+/**
+ * Gets the username defined by the current URL, if any
+ *
+ * @returns {string|null} username
+ */
+export function getUserNameFromUrl() {
+  const searchParams = new URLSearchParams(window.location.search)
+  if (searchParams.has('username')) {
+    return searchParams.get('username')
+  } else {
+    return null
+  }
+}

--- a/src/lib/utils.spec.js
+++ b/src/lib/utils.spec.js
@@ -1,7 +1,8 @@
 import {
   getSharedDocument,
   fetchIfIsNoteReadOnly,
-  getFolderLink
+  getFolderLink,
+  getUserNameFromUrl
 } from './utils'
 
 function setupClient(verbs = [], ids = ['first', 'other']) {
@@ -135,5 +136,20 @@ describe('getFolderLink', () => {
       const id = 'io.cozy.files.root-dir'
       expect(getFolderLink(id)).toEqual('/folder/io.cozy.files.root-dir')
     })
+  })
+})
+
+describe('getUserNameFromUrl', () => {
+  it('should return the url part', () => {
+    window.history.pushState(
+      {},
+      'Test Title',
+      '/test.html?username=hello+world'
+    )
+    expect(getUserNameFromUrl()).toEqual('hello world')
+  })
+  it('should return null when not present', () => {
+    window.history.pushState({}, 'Test Title', '/test.html')
+    expect(getUserNameFromUrl()).toBeNull()
   })
 })


### PR DESCRIPTION
In collaboration mode, we show initials attached to each cursors. We also plan to display avatars in the future.

This PR allows a cozy to send the editor name when building a link, and have the correct name first letter.

It also remove old placeholder data (email and avatar) which are not displayed today but were throwing CSP errors in the console.
