### PR TITLE
feat: Shows date of previous doc update

### DIFF
--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -42,7 +42,7 @@ const Editor = withClient(function(props) {
   const collabProvider = useCollabProvider({
     noteId,
     serviceClient,
-    docVersion: doc && doc.version
+    doc
   })
 
   // callbacks

--- a/src/hooks/useCollabProvider.js
+++ b/src/hooks/useCollabProvider.js
@@ -14,16 +14,18 @@ import CollabProvider from 'lib/collab/provider'
  * @param {useCollabProviderParams} params
  * @returns {CollabProvider|undefined}
  */
-function useCollabProvider({ docVersion, noteId, serviceClient }) {
+function useCollabProvider({ doc, noteId, serviceClient }) {
   return useMemo(() => {
-    if (serviceClient && docVersion !== undefined) {
+    const version = doc && doc.version
+    const updatedAt = doc && doc.updatedAt
+    if (serviceClient && doc !== undefined) {
       const provider = new CollabProvider(
-        { version: docVersion, noteId },
+        { version, noteId, updatedAt },
         serviceClient
       )
       return provider
     }
-  }, [noteId, docVersion, serviceClient])
+  }, [noteId, doc, serviceClient])
 }
 
 export default useCollabProvider

--- a/src/lib/collab/channel.js
+++ b/src/lib/collab/channel.js
@@ -204,7 +204,7 @@ export class Channel {
   /**
    * Connect to pubsub to start receiving events
    */
-  async connect(version, doc) {
+  async connect({ version, doc, updatedAt }) {
     const { noteId } = this.config
     this.service.join(noteId)
     this.service.onStepsCreated(noteId, data => {
@@ -213,10 +213,7 @@ export class Channel {
     this.service.onTelepointerUpdated(noteId, payload => {
       this.emit('telepointer', payload)
     })
-    this.emit('connected', {
-      doc,
-      version
-    })
+    this.emit('connected', { version, doc, updatedAt })
   }
 
   /**

--- a/src/lib/collab/channel.spec.js
+++ b/src/lib/collab/channel.spec.js
@@ -434,7 +434,7 @@ describe('Channel', () => {
         expect(data.version).toBe(version)
         done()
       })
-      await channel.connect(version, doc)
+      await channel.connect({ version, doc })
     })
   })
 

--- a/src/lib/collab/stack-client.js
+++ b/src/lib/collab/stack-client.js
@@ -217,6 +217,7 @@ export class ServiceClient {
       doc: res.data.attributes.metadata.content,
       version: res.data.attributes.metadata.version,
       title: res.data.attributes.metadata.title,
+      updatedAt: new Date(res.data.attributes.updated_at),
       file: res.data
     }
   }


### PR DESCRIPTION
Previously, the last saving date was initialized
with the time when the document was opened.

With this change, we reuse the updatedAt date
inside the document itself.