### PR TITLE
chore: Bump vesion

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -4,7 +4,7 @@
   "slug": "notes",
   "icon": "icon.svg",
   "categories": ["cozy"],
-  "version": "1.8.0",
+  "version": "1.11.0",
   "licence": "AGPL-3.0",
   "editor": "Cozy",
   "source": "https://github.com/cozy/cozy-notes.git@build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-notes",
-  "version": "1.8.0",
+  "version": "1.11.0",
   "scripts": {
     "tx": "tx pull --all || true",
     "lint": "yarn lint:js && yarn lint:styles",


### PR DESCRIPTION
We currently have a 1.10.0 in beta. Let's publish a 1.11.0-dev to check if the deployment works. 