### PR TITLE
feat: Initial of ? for unknown public user

### DIFF
--- a/src/hooks/useUser.js
+++ b/src/hooks/useUser.js
@@ -1,13 +1,14 @@
-import { useMemo } from 'react'
-
+import { useMemo, useContext } from 'react'
+import IsPublicContext from 'components/IsPublicContext'
 import { getShortNameFromClient, getUserNameFromUrl } from 'lib/utils.js'
 
 function useUser({ userName: providedUserName, cozyClient }) {
+  const isPublic = useContext(IsPublicContext)
   const userName = useMemo(
     () =>
       providedUserName ||
       getUserNameFromUrl() ||
-      getShortNameFromClient(cozyClient),
+      (isPublic ? '?' : getShortNameFromClient(cozyClient)),
     [cozyClient, providedUserName]
   )
   const userId = userName

--- a/src/hooks/useUser.spec.js
+++ b/src/hooks/useUser.spec.js
@@ -1,17 +1,39 @@
+import React from 'react'
 import useUser from './useUser'
+import IsPublicContext from '../components/IsPublicContext'
 
 import { renderHook } from '@testing-library/react-hooks'
+
+function withPublicContext(value) {
+  // eslint-disable-next-line react/display-name
+  return props => (
+    <IsPublicContext.Provider value={value}>
+      {props.children}
+    </IsPublicContext.Provider>
+  )
+}
+
+function setUrlUsername(username) {
+  const params = username ? 'username=' + encodeURI(username) : ''
+  const url = '/test.html?' + params
+  window.history.pushState({}, 'Test Title', url)
+}
 
 describe('useUser', () => {
   describe('with an explicit username in the url', () => {
     it('should return  this username', () => {
-      window.history.pushState(
-        {},
-        'Test Title',
-        '/test.html?username=hello+world'
-      )
+      setUrlUsername('hello world')
       const { result } = renderHook(() => useUser({}))
       expect(result.current.userName).toEqual('hello world')
+    })
+  })
+
+  describe('for a public view', () => {
+    it('shows an unknown initial', () => {
+      const context = withPublicContext(true)
+      setUrlUsername(null)
+      const { result } = renderHook(() => useUser({}), { wrapper: context })
+      expect(result.current.userName[0]).toEqual('?')
     })
   })
 })


### PR DESCRIPTION
For a share by link, if the visitor does not provide an
explicit username, use '?' as initial for his cursors.
