### PR TITLE
fix: Edit a note on the correct cozy instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@atlaskit/smart-card": "12.6.2",
     "@material-ui/core": "3.9.4",
     "cozy-bar": "7.7.8",
-    "cozy-client": "10.8.1",
+    "cozy-client": "13.1.2",
     "cozy-device-helper": "1.8.0",
     "cozy-doctypes": "1.70.0",
     "cozy-flags": "2.1.0",

--- a/src/components/notes/List/NoteRow.jsx
+++ b/src/components/notes/List/NoteRow.jsx
@@ -44,9 +44,10 @@ const NoteRow = ({ note, f, t, client, breakpoints: { isMobile } }) => {
     <>
       <TableRow
         className={`u-c-pointer ${styles.tableRow}`}
-        onClick={() =>
-          (window.location.href = generateReturnUrlToNotesIndex(note))
-        }
+        onClick={async () => {
+          const url = await generateReturnUrlToNotesIndex(client, note)
+          window.location.href = url
+        }}
       >
         <TableCell
           className={`${styles.tableCellName} u-flex u-flex-items-center u-ellipsis u-fz-medium`}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -23,11 +23,19 @@ export function getReturnUrl() {
   return undefined
 }
 
-export const generateReturnUrlToNotesIndex = doc => {
-  const url = new URL(window.location)
-  url.searchParams.set(returnUrlKey, '#/')
-  url.hash = `#/n/${doc.id}`
-  return url
+/**
+ * Create the URL to be used to edit a note
+ *
+ * @param {CozyClient} client
+ * @param {object} doc - couchdb document for the note/file
+ * @return {string} URL where one can edit the note
+ */
+export async function generateReturnUrlToNotesIndex(client, doc) {
+  const rawUrl = models.note.fetchURL(client, doc)
+  const back = window.location.toString()
+  const dest = new URL(await rawUrl)
+  dest.searchParams.set(returnUrlKey, back)
+  return dest.toString()
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5377,21 +5377,21 @@ cozy-bar@7.7.8:
     redux-persist "5.10.0"
     redux-thunk "2.3.0"
 
-cozy-client@10.8.1:
-  version "10.8.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-10.8.1.tgz#e9887cae8717baf837bc59f8fc0a514cbb01ca82"
-  integrity sha512-Bc2SYiHvfYTkklLaMvWnUuTdkkMAo6wtQ8iK3MbW6zb7tVIFMsYno7fihsnRUg9AMX8Swl6FmP8YZSIEqs3Xvw==
+cozy-client@13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-13.1.2.tgz#fb6ef51ea39cf752c4709bb1ddad1aeb40567a1e"
+  integrity sha512-szEm3spv685mOh4/6zh2tdnlwXDuSzaKyDFC/fjuHgOK+/BpvHggzuMp9maMBYa5ewjQakVF5HdeBBh/MTwb2Q==
   dependencies:
     btoa "^1.2.1"
     cozy-device-helper "^1.7.3"
     cozy-logger "^1.6.0"
-    cozy-stack-client "^10.7.0"
+    cozy-stack-client "^13.1.0"
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.13"
     microee "^0.0.6"
     open "^7.0.2"
     prop-types "^15.6.2"
-    react-redux "^5.0.7"
+    react-redux "^7.2.0"
     redux "^3.7.2"
     redux-thunk "^2.3.0"
     server-destroy "^1.0.1"
@@ -5555,10 +5555,10 @@ cozy-sharing@1.8.5:
     react-autosuggest "^9.4.3"
     react-tooltip "^3.11.1"
 
-cozy-stack-client@^10.7.0:
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-10.7.0.tgz#2f9a886af423abe9111d6c1524104c29d2ed517f"
-  integrity sha512-O2z9sFwDhcbn/rZJr0f2BL3CAc2L37QMzmIlQXY/70x/SqkSd+zyFhgwfYImqlwYsByf6Mo6qwtpwv5goRj9Ig==
+cozy-stack-client@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-13.1.0.tgz#72a1c8a9b4c3c24e32f0d6ff66c46b576cad9827"
+  integrity sha512-5DavkdIrLsOVdHBkvTmzrjVzSMh5S2utF1dW+1zfCYAUde7/XbPDRK6S2ct+Lfd0NcRbUK2oJUEpyNXMBqrrjw==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
@@ -13268,18 +13268,16 @@ react-redux@5.1.1, react-redux@^5.0.0:
     react-is "^16.6.0"
     react-lifecycles-compat "^3.0.0"
 
-react-redux@^5.0.7:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.1.2.tgz#b19cf9e21d694422727bf798e934a916c4080f57"
-  integrity sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==
+react-redux@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.0.tgz#f970f62192b3981642fec46fd0db18a074fe879d"
+  integrity sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==
   dependencies:
-    "@babel/runtime" "^7.1.2"
+    "@babel/runtime" "^7.5.5"
     hoist-non-react-statics "^3.3.0"
-    invariant "^2.2.4"
-    loose-envify "^1.1.0"
-    prop-types "^15.6.1"
-    react-is "^16.6.0"
-    react-lifecycles-compat "^3.0.0"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 react-render-image@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
Previously, clicking on a note in the index always redirect
to the editor's instance. This was creating duplicates and
conflicts when the note was created on another instance.
It now correctly redirects to the first author's instance.