### PR TITLE
fix: Notes creation on mobile

### DIFF
--- a/src/components/notes/List/index.jsx
+++ b/src/components/notes/List/index.jsx
@@ -1,8 +1,8 @@
 /* global cozy */
 import React from 'react'
 import Stack from 'cozy-ui/react/Stack'
-import { withBreakpoints } from 'cozy-ui/react'
-import { Query, Q } from 'cozy-client'
+import { withBreakpoints, BarContextProvider, useI18n } from 'cozy-ui/react'
+import { Query, Q, useClient } from 'cozy-client'
 import AppTitle from 'components/notes/List/AppTitle'
 import List from 'components/notes/List/List'
 import Add, { AddMobile } from 'components/notes/add'
@@ -12,6 +12,8 @@ const shouldDisplayAddButton = (fetchStatus, notes) =>
 
 const ListView = ({ breakpoints: { isMobile } }) => {
   const { BarRight } = cozy.bar
+  const i18n = useI18n()
+  const client = useClient()
 
   return (
     <Query query={() => Q('io.cozy.notes')}>
@@ -31,7 +33,13 @@ const ListView = ({ breakpoints: { isMobile } }) => {
             </Stack>
             {isMobile && shouldDisplayAddButton(fetchStatus, notes) && (
               <BarRight>
-                <AddMobile />
+                <BarContextProvider
+                  store={client.store}
+                  client={client}
+                  {...i18n}
+                >
+                  <AddMobile />
+                </BarContextProvider>
               </BarRight>
             )}
           </>

--- a/src/components/notes/add.jsx
+++ b/src/components/notes/add.jsx
@@ -1,14 +1,16 @@
 import React, { useState, useCallback } from 'react'
 
-import { withClient } from 'cozy-client'
+import { useClient } from 'cozy-client'
 
 import Button from 'cozy-ui/react/Button'
-import { translate } from 'cozy-ui/react/I18n'
+import { useI18n } from 'cozy-ui/react/I18n'
 import BarButton from 'cozy-ui/react/BarButton'
 
 import { createNoteDocument, generateReturnUrlToNotesIndex } from 'lib/utils'
 
-const Add = ({ t, className, client }) => {
+export default function Add({ className }) {
+  const { t } = useI18n()
+  const client = useClient()
   const [isWorking, setIsWorking] = useState(false)
   const handleClick = useCallback(async () => {
     setIsWorking(true)
@@ -29,14 +31,16 @@ const Add = ({ t, className, client }) => {
   )
 }
 
-export const AddMobile = withClient(({ client }) => (
-  <BarButton
-    onClick={async () => {
-      const { data: doc } = await createNoteDocument(client)
-      window.location.href = await generateReturnUrlToNotesIndex(client, doc)
-    }}
-    icon="plus"
-    className="u-c-pointer"
-  />
-))
-export default translate()(withClient(Add))
+export function AddMobile(props) {
+  const client = useClient() || props.client
+  return (
+    <BarButton
+      onClick={async () => {
+        const { data: doc } = await createNoteDocument(client)
+        window.location.href = await generateReturnUrlToNotesIndex(client, doc)
+      }}
+      icon="plus"
+      className="u-c-pointer"
+    />
+  )
+}


### PR DESCRIPTION
The update of cozy-client broke the "+" button on mobile.
The AddMobile component uses the withClient / useClient of the
new cozy-client, which relies on the new Context feature of React.
The bar only provides the old Context feature in its tree.
When the AddMobile is inserted into the bar, it cannot find the
cozyClient instance in the tree, and fails.
