### PR TITLE
fix: Forbid carriage return and line feed in title

### DIFF
--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -37,8 +37,6 @@ function EditorView(props) {
 
   const onTitleEvent = useCallback(
     e => {
-      const target = e.target
-      updateTextareaHeight(target)
       if (onTitleChange) onTitleChange(e)
     },
     [onTitleChange]
@@ -62,7 +60,7 @@ function EditorView(props) {
     [collabProvider]
   )
 
-  useEffect(() => updateTextareaHeight(titleEl.current), [])
+  useEffect(() => updateTextareaHeight(titleEl.current), [title])
 
   useEventListener(titleEl.current, 'blur', onTitleBlur)
 

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useContext, useCallback, useRef } from 'react'
 
-import { withClient } from 'cozy-client'
+import { useClient } from 'cozy-client'
 
 import EditorView from 'components/notes/editor-view'
 import EditorLoading from 'components/notes/editor-loading'
@@ -21,9 +21,10 @@ import { useDebugValue } from 'lib/debug'
 import useConfirmExit from 'cozy-ui/react/hooks/useConfirmExit'
 import { useI18n } from 'cozy-ui/react/I18n'
 
-const Editor = withClient(function(props) {
+export default function Editor(props) {
   // base parameters
-  const { client: cozyClient, noteId, readOnly } = props
+  const cozyClient = useClient()
+  const { noteId, readOnly } = props
   const { t } = useI18n()
   const bannerRef = useRef() // where to display banners
 
@@ -113,6 +114,4 @@ const Editor = withClient(function(props) {
   } else {
     return <EditorLoadingError returnUrl={returnUrl} />
   }
-})
-
-export default Editor
+}

--- a/src/hooks/useTitleChanges.js
+++ b/src/hooks/useTitleChanges.js
@@ -6,7 +6,8 @@ function useTitleChanges({ noteId, title, setTitle, serviceClient }) {
   const onLocalTitleChange = useCallback(
     serviceClient
       ? e => {
-          const modifiedTitle = e.target.value
+          // forbid line feed and non standard spaces in title
+          const modifiedTitle = e.target.value.replace(/[\r\t\n\xa0]+/g, ' ')
           if (title != modifiedTitle) {
             setTitle(modifiedTitle)
             serviceClient.setTitle(noteId, modifiedTitle)

--- a/src/hooks/useTitleChanges.spec.js
+++ b/src/hooks/useTitleChanges.spec.js
@@ -1,0 +1,113 @@
+import useTitleChanges from './useTitleChanges'
+import { renderHook, act } from '@testing-library/react-hooks'
+
+import {} from 'lib/utils.js'
+jest.mock('lib/utils.js')
+
+function createServiceClient() {
+  return {
+    setTitle: jest.fn(),
+    onTitleUpdated: jest.fn()
+  }
+}
+function createTitleChangeEvent(title) {
+  return { target: { value: title } }
+}
+
+const serviceClient = createServiceClient()
+const setTitle = jest.fn()
+const noteId = '1234'
+const title = 'my title'
+
+describe('useTitleChanges', () => {
+  describe('onLocalTitleChange', () => {
+    it('is a function', () => {
+      const params = { noteId, title, setTitle, serviceClient }
+      const { result } = renderHook(() => useTitleChanges(params))
+      expect(result.current.onLocalTitleChange).toBeInstanceOf(Function)
+    })
+
+    it('forwards to setTitle', async () => {
+      const setTitle = jest.fn()
+      const params = { noteId, title, setTitle, serviceClient }
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useTitleChanges(params)
+      )
+      const next = waitForNextUpdate
+      const { onLocalTitleChange } = result.current
+      act(() => {
+        const event = createTitleChangeEvent('new title')
+        onLocalTitleChange(event)
+      })
+      await next
+      expect(setTitle).toHaveBeenCalledWith('new title')
+    })
+
+    it('forwards to the stack', async () => {
+      const serviceClient = createServiceClient()
+      const params = { noteId, title, setTitle, serviceClient }
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useTitleChanges(params)
+      )
+      const next = waitForNextUpdate
+      const { onLocalTitleChange } = result.current
+      act(() => {
+        const event = createTitleChangeEvent('new title')
+        onLocalTitleChange(event)
+      })
+      await next
+      expect(serviceClient.setTitle).toHaveBeenCalledWith(noteId, 'new title')
+    })
+
+    describe('when the title does not change', () => {
+      it('does not forward to setTitle', async () => {
+        const setTitle = jest.fn()
+        const params = { noteId, title, setTitle, serviceClient }
+        const { result, waitForNextUpdate } = renderHook(() =>
+          useTitleChanges(params)
+        )
+        const next = waitForNextUpdate
+        const { onLocalTitleChange } = result.current
+        act(() => {
+          const event = createTitleChangeEvent(title)
+          onLocalTitleChange(event)
+        })
+        await next
+        expect(setTitle).not.toHaveBeenCalled()
+      })
+
+      it('does not forward to the stack', async () => {
+        const serviceClient = createServiceClient()
+        const params = { noteId, title, setTitle, serviceClient }
+        const { result, waitForNextUpdate } = renderHook(() =>
+          useTitleChanges(params)
+        )
+        const next = waitForNextUpdate
+        const { onLocalTitleChange } = result.current
+        act(() => {
+          const event = createTitleChangeEvent(title)
+          onLocalTitleChange(event)
+        })
+        await next
+        expect(serviceClient.setTitle).not.toHaveBeenCalled()
+      })
+    })
+    describe('for a title with line feeds', () => {
+      it('does remove the line feeds', async () => {
+        const setTitle = jest.fn()
+        const params = { noteId, title, setTitle, serviceClient }
+        const { result, waitForNextUpdate } = renderHook(() =>
+          useTitleChanges(params)
+        )
+        const next = waitForNextUpdate
+        const { onLocalTitleChange } = result.current
+        act(() => {
+          const event = createTitleChangeEvent('new\r\ntitle')
+          onLocalTitleChange(event)
+        })
+        await next
+        expect(setTitle).toHaveBeenCalledWith('new title')
+      })
+    })
+  })
+})


### PR DESCRIPTION
Line feeds in title break both the title display in the note and the file name in couch.
