### PR TITLE
fix: Don't load SharingProvider if we're in a public context

### DIFF
--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -50,9 +50,12 @@ const renderApp = function(client, isPublic) {
         <CozyProvider client={client}>
           <MuiCozyTheme>
             <IsPublicContext.Provider value={isPublic}>
-              <SharingProvider doctype="io.cozy.files" documentType="Notes">
-                <App isPublic={isPublic} />
-              </SharingProvider>
+              {!isPublic && (
+                <SharingProvider doctype="io.cozy.files" documentType="Notes">
+                  <App isPublic={isPublic} />
+                </SharingProvider>
+              )}
+              {isPublic && <App isPublic={isPublic} />}
             </IsPublicContext.Provider>
           </MuiCozyTheme>
         </CozyProvider>


### PR DESCRIPTION
We recently added the SharingProvider to get the sharing state. But we don't want to mount the SharingProvider if we're in a public context. Mounting it results by querying "shared-by-link" and other and throw errors.