### PR TITLE
Editable/uneditable shared notes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
     - node_modules
 script:
   - yarn lint
-  - yarn test
+  - yarn test --coverage
   - yarn build
 before_deploy:
   - yarn add cozy-app-publish

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
     '^cozy-client$': 'cozy-client/dist/index.js',
     '^cozy-ui/react(.*)$': 'cozy-ui/transpiled/react$1'
   },
-  transformIgnorePatterns: ['node_modules/(?!cozy-ui)'],
+  transformIgnorePatterns: ['node_modules/(?!cozy-(ui|sharing))'],
   transform: {
     '^.+\\.webapp$': '<rootDir>/test/jestLib/json-transformer.js',
     '^.+\\.(js|jsx)?$': '<rootDir>/test/jestLib/babel-transformer.js'

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cozy-flags": "2.1.0",
     "cozy-realtime": "3.7.0",
     "cozy-scripts": "2.0.2",
-    "cozy-sharing": "1.8.5",
+    "cozy-sharing": "1.11.0",
     "cozy-ui": "35.1.0",
     "eslint-config-cozy-app": "1.3.3",
     "lodash": "4.17.15",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "cozy-ui": "35.22.0",
     "eslint-config-cozy-app": "1.3.3",
     "lodash": "4.17.15",
+    "prop-types": "^15.7.2",
     "react": "16.12.0",
     "react-dom": "16.12.0",
     "react-intl": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "cozy-realtime": "3.7.0",
     "cozy-scripts": "2.0.2",
     "cozy-sharing": "1.11.0",
-    "cozy-ui": "35.1.0",
+    "cozy-ui": "35.22.0",
     "eslint-config-cozy-app": "1.3.3",
     "lodash": "4.17.15",
     "react": "16.12.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "watch:mobile": "cs watch --mobile",
     "start": "cs start --hot --browser",
     "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo ${DEPLOY_REPOSITORY:-https://cozy-bot:$GITHUB_TOKEN@github.com/cozy/cozy-notes}",
-    "test": "cs test --verbose",
+    "test": "env NODE_ENV='test' cs test --verbose",
     "cozyPublish": "cs publish --token $REGISTRY_TOKEN --build-commit $(git rev-parse ${DEPLOY_BRANCH:-build})"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "watch:mobile": "cs watch --mobile",
     "start": "cs start --hot --browser",
     "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo ${DEPLOY_REPOSITORY:-https://cozy-bot:$GITHUB_TOKEN@github.com/cozy/cozy-notes}",
-    "test": "cs test --verbose --coverage",
+    "test": "cs test --verbose",
     "cozyPublish": "cs publish --token $REGISTRY_TOKEN --build-commit $(git rev-parse ${DEPLOY_BRANCH:-build})"
   },
   "repository": {

--- a/src/components/notes/EditorCorner.jsx
+++ b/src/components/notes/EditorCorner.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Icon from 'cozy-ui/react/Icon'
+import Tooltip from 'cozy-ui/react/Tooltip'
+
+import SharingWidget from 'components/notes/sharing'
+
+const EditorCorner = ({ doc, isPublic, isReadOnly }) => {
+  if (!isPublic) return <SharingWidget file={doc.file} />
+  else if (isReadOnly)
+    return (
+      <Tooltip title={'This note is in read-only mode.'}>
+        <Icon icon="lock" color="var(--primaryTextColor)" />
+      </Tooltip>
+    )
+  else return false
+}
+
+EditorCorner.propTypes = {
+  doc: PropTypes.object.isRequired,
+  isPublic: PropTypes.bool.isRequired,
+  isReadOnly: PropTypes.bool.isRequired
+}
+
+export default EditorCorner

--- a/src/components/notes/EditorCorner.spec.jsx
+++ b/src/components/notes/EditorCorner.spec.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import SharingWidget from 'components/notes/sharing'
+import EditorCorner from './EditorCorner'
+
+describe('EditorCorner', () => {
+  const mockDoc = {}
+  it('shows the sharing widget on private views', () => {
+    const readOnlyComponent = shallow(
+      <EditorCorner doc={mockDoc} isPublic={false} isReadOnly={true} />
+    )
+    expect(readOnlyComponent.find(SharingWidget).length).toBe(1)
+
+    const editableComponent = shallow(
+      <EditorCorner doc={mockDoc} isPublic={false} isReadOnly={false} />
+    )
+    expect(editableComponent.find(SharingWidget).length).toBe(1)
+  })
+
+  it('shows a read only indication on public views', () => {
+    const component = shallow(
+      <EditorCorner doc={mockDoc} isPublic={true} isReadOnly={true} />
+    )
+    expect(component.getElement()).toMatchInlineSnapshot(`
+      <WithStyles(WithStyles(Tooltip))
+        title="This note is in read-only mode."
+      >
+        <Icon
+          color="var(--primaryTextColor)"
+          icon="lock"
+          spin={false}
+        />
+      </WithStyles(WithStyles(Tooltip))>
+    `)
+  })
+
+  it('renders nothing on a public view with write permissions', () => {
+    const component = shallow(
+      <EditorCorner doc={mockDoc} isPublic={true} isReadOnly={false} />
+    )
+
+    expect(component.getElement()).toBe(null)
+  })
+})

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types'
 import { useClient } from 'cozy-client'
 
 import EditorView from 'components/notes/editor-view'
+import EditorCorner from 'components/notes/EditorCorner'
 import EditorLoading from 'components/notes/editor-loading'
 import EditorLoadingError from 'components/notes/editor-loading-error'
-import SharingWidget from 'components/notes/sharing'
 import SavingIndicator from 'components/notes/saving-indicator'
 import BackFromEditing from 'components/notes/back_from_editing'
 import IsPublicContext from 'components/IsPublicContext'
@@ -103,7 +103,9 @@ export default function Editor(props) {
               requestToLeave={requestToLeave}
             />
           }
-          rightComponent={!isPublic && <SharingWidget file={doc.file} />}
+          rightComponent={
+            <EditorCorner doc={doc} isPublic={isPublic} isReadOnly={readOnly} />
+          }
         />
         <SavingIndicator
           collabProvider={collabProvider}

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useContext, useCallback, useRef } from 'react'
+import PropTypes from 'prop-types'
 
 import { useClient } from 'cozy-client'
 
@@ -114,4 +115,11 @@ export default function Editor(props) {
   } else {
     return <EditorLoadingError returnUrl={returnUrl} />
   }
+}
+
+Editor.propTypes = {
+  noteId: PropTypes.string.isRequired,
+  readOnly: PropTypes.bool.isRequired,
+  userName: PropTypes.string,
+  returnUrl: PropTypes.string
 }

--- a/src/components/notes/sharing.jsx
+++ b/src/components/notes/sharing.jsx
@@ -1,35 +1,33 @@
 import React, { useCallback, useState } from 'react'
-import { ShareButton, ShareModal, withLocales } from 'cozy-sharing'
+import { ShareButton, ShareModal } from 'cozy-sharing'
 import { withClient } from 'cozy-client'
 
 import useFileWithPath from 'hooks/useFileWithPath'
 import styles from 'components/notes/sharing.styl'
 
-export default withLocales(
-  withClient(function SharingWidget(props) {
-    const { client } = props
+export default withClient(function SharingWidget(props) {
+  const { client } = props
 
-    const file = useFileWithPath({ cozyClient: client, file: props.file })
-    const noteId = file && file.id
+  const file = useFileWithPath({ cozyClient: client, file: props.file })
+  const noteId = file && file.id
 
-    const [showModal, setShowModal] = useState(false)
-    const onClick = useCallback(() => setShowModal(!showModal), [showModal])
-    const onClose = useCallback(() => setShowModal(false), [])
+  const [showModal, setShowModal] = useState(false)
+  const onClick = useCallback(() => setShowModal(!showModal), [showModal])
+  const onClose = useCallback(() => setShowModal(false), [])
 
-    return (
-      (file && (
-        <>
-          <ShareButton
-            theme="primary"
-            docId={noteId}
-            onClick={onClick}
-            extension="narrow"
-            className={styles['sharing-button']}
-          />
-          {showModal && <ShareModal document={file} onClose={onClose} />}
-        </>
-      )) ||
-      null
-    )
-  })
-)
+  return (
+    (file && (
+      <>
+        <ShareButton
+          theme="primary"
+          docId={noteId}
+          onClick={onClick}
+          extension="narrow"
+          className={styles['sharing-button']}
+        />
+        {showModal && <ShareModal document={file} onClose={onClose} />}
+      </>
+    )) ||
+    null
+  )
+})

--- a/src/components/notes/sharing.jsx
+++ b/src/components/notes/sharing.jsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useState } from 'react'
 import { ShareButton, ShareModal } from 'cozy-sharing'
-import { withClient } from 'cozy-client'
+import { useClient } from 'cozy-client'
 
 import useFileWithPath from 'hooks/useFileWithPath'
 import styles from 'components/notes/sharing.styl'
 
-export default withClient(function SharingWidget(props) {
-  const { client } = props
+export default function SharingWidget(props) {
+  const client = useClient()
 
   const file = useFileWithPath({ cozyClient: client, file: props.file })
   const noteId = file && file.id
@@ -30,4 +30,4 @@ export default withClient(function SharingWidget(props) {
     )) ||
     null
   )
-})
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5640,10 +5640,10 @@ cozy-ui@22.3.1:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@35.1.0:
-  version "35.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.1.0.tgz#df5dd3e601c8d2b73860b03e6924ee986c7ea477"
-  integrity sha512-F9husNZbFFfI6LzMi9nZpub7RyYdbsK5mQ1DPfxRRGZREF0ujNPoprIuEznKA2tG8KZYj5Ry+xZqeBh1Kxp9AA==
+cozy-ui@35.22.0:
+  version "35.22.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.22.0.tgz#ce8e1703740a27073b3cff812f9a7027d3a27e41"
+  integrity sha512-oAP+EIgS4D2J2Y7CiRNPbR9jCFrDrkiLIfpQeWkTjFbGXiCkJTdQabAx7fiZdcI0gxCo9OCv7mhtirMHv/ylKw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"
@@ -10760,13 +10760,6 @@ minilog@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/minilog/-/minilog-3.1.0.tgz#d2d0f1887ca363d1acf0ea86d5c4df293b3fb675"
   integrity sha1-0tDxiHyjY9Gs8OqG1cTfKTs/tnU=
-  dependencies:
-    microee "0.0.6"
-
-"minilog@git+https://github.com/cozy/minilog.git#master":
-  version "3.1.0"
-  uid f01f7d9dfe20981177dd34b9662c2f077d818f82
-  resolved "git+https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
   dependencies:
     microee "0.0.6"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5471,13 +5471,6 @@ cozy-device-helper@1.8.0, cozy-device-helper@^1.7.3:
   dependencies:
     lodash "4.17.15"
 
-cozy-device-helper@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.9.0.tgz#de291c524893fe4f927b2262fb6bb71894913d6f"
-  integrity sha512-BK6ebCLb9v9GYIm/yOBZHrQ6WDttV3Mjmdm6ndZoVdsBIOCerqfxl5+pPCyUfSyvkfgk+01XDDNiOg0GGi07+A==
-  dependencies:
-    lodash "4.17.15"
-
 cozy-device-helper@^1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.9.2.tgz#cccddb08011c89620fefac96bb894708c1f27f7b"
@@ -5497,10 +5490,10 @@ cozy-doctypes@1.70.0:
     lodash "4.17.15"
     prop-types "^15.7.2"
 
-cozy-doctypes@^1.72.0:
-  version "1.72.0"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.72.0.tgz#42f9a5823b37c181ef60f949532ba70066c4cedb"
-  integrity sha512-KFezh/TsOFed2SX1q+TNSaWBx2gfEdGwEfRQA9nka6P3Bn3DZCSk8SKIXGa9nnnHOJedGPtN/L55mvpu7wG4dg==
+cozy-doctypes@^1.72.2:
+  version "1.72.2"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.72.2.tgz#ac3d6813780008e5a4115a70679a0f25cf7efd81"
+  integrity sha512-ITrfljuDBsRQ4AaDUup+0Weh7K+QlZfX38R1YFw9nsLWZMy8GCvUvaJ6vLk7UWj9SmoO/+A2Dwz2T/p9je+DZA==
   dependencies:
     "@babel/runtime" "7.5.5"
     cozy-logger "^1.6.0"
@@ -5544,12 +5537,12 @@ cozy-realtime@3.7.0:
     cozy-device-helper "^1.9.2"
     minilog "https://github.com/cozy/minilog.git#master"
 
-cozy-realtime@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.6.0.tgz#a4a2b841c5f5178e2832f54df43b00f5cd9681f5"
-  integrity sha512-7s3jyx73796v19jZTLbjCVY+uWDu8xhvxLeuX1xplx0NRcoZLbEYwT2TIO8evAqASze3dKD2YC5q3V1WDmGQQA==
+cozy-realtime@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.8.0.tgz#b161b105433d957f7cb68332ee3fe58e082d7cb4"
+  integrity sha512-VCgffHdMcqO8LRHnUZijR0UXE5FwdLGh9BOP0WKN6lP5eOEaRFL+OPfJuHJasgN5r1YfXautbze1wRQZByAcEg==
   dependencies:
-    cozy-device-helper "^1.9.0"
+    cozy-device-helper "^1.9.2"
     minilog "https://github.com/cozy/minilog.git#master"
 
 cozy-scripts@2.0.2:
@@ -5605,17 +5598,17 @@ cozy-scripts@2.0.2:
     webpack-dev-server "3.7.2"
     webpack-merge "4.2.1"
 
-cozy-sharing@1.8.5:
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-1.8.5.tgz#a891a31affbfa01e13904ebdeed79678797b9e3e"
-  integrity sha512-Z1gVwc9g/42y77g54LKGoGFSdhPfFwXO8rtnfKTqa4/nqA+65BpSCLYmFqBGVHhAt2eBdBUa6cVO8OqyvtniGQ==
+cozy-sharing@1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-1.11.0.tgz#de30fffa73c17f7e0c4d8c98824e77dd75622ac0"
+  integrity sha512-T92ST1OsGB/hC7ZS/fxWX14SIqqX16IMQptf6Oi63dQYDu+J2vMLj2W6/6KFgB9TDUqu98wP7pYWYM54DKnKOQ==
   dependencies:
     babel-plugin-inline-react-svg "^1.1.0"
     classnames "^2.2.6"
     copy-text-to-clipboard "^2.1.1"
-    cozy-device-helper "^1.9.0"
-    cozy-doctypes "^1.72.0"
-    cozy-realtime "^3.6.0"
+    cozy-device-helper "^1.9.2"
+    cozy-doctypes "^1.72.2"
+    cozy-realtime "^3.8.0"
     lodash "^4.17.15"
     minilog "https://github.com/cozy/minilog.git#master"
     react-autosuggest "^9.4.3"
@@ -10767,6 +10760,13 @@ minilog@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/minilog/-/minilog-3.1.0.tgz#d2d0f1887ca363d1acf0ea86d5c4df293b3fb675"
   integrity sha1-0tDxiHyjY9Gs8OqG1cTfKTs/tnU=
+  dependencies:
+    microee "0.0.6"
+
+"minilog@git+https://github.com/cozy/minilog.git#master":
+  version "3.1.0"
+  uid f01f7d9dfe20981177dd34b9662c2f077d818f82
+  resolved "git+https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
   dependencies:
     microee "0.0.6"
 


### PR DESCRIPTION
This PR updates cozy-sharing to the latest version where instead of a hard-coded behavior for Notes, the user can choose if a note should be shared with or without editing permissions.

We also added a small indicator about a note being uneditable when that's the case:

<img width="616" alt="Capture d'écran 2020-06-02 10 59 34" src="https://user-images.githubusercontent.com/2261445/83501319-3b130600-a4c0-11ea-8c20-91b29265ac2f.png">

Requires https://github.com/cozy/cozy-libs/pull/1015

