### PR TITLE
fix: Use tranlated string for read-only mode

### DIFF
--- a/src/components/notes/EditorCorner.jsx
+++ b/src/components/notes/EditorCorner.jsx
@@ -3,18 +3,20 @@ import PropTypes from 'prop-types'
 
 import Icon from 'cozy-ui/react/Icon'
 import Tooltip from 'cozy-ui/react/Tooltip'
+import { useI18n } from 'cozy-ui/react/I18n'
 
 import SharingWidget from 'components/notes/sharing'
 
 const EditorCorner = ({ doc, isPublic, isReadOnly }) => {
   if (!isPublic) return <SharingWidget file={doc.file} />
-  else if (isReadOnly)
+  else if (isReadOnly) {
+    const { t } = useI18n()
     return (
-      <Tooltip title={'This note is in read-only mode.'}>
+      <Tooltip title={t('Notes.Editor.read_only')}>
         <Icon icon="lock" color="var(--primaryTextColor)" />
       </Tooltip>
     )
-  else return false
+  } else return false
 }
 
 EditorCorner.propTypes = {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,7 +16,8 @@
       "exit_confirmation_message": "Automatic saving has not taken into account the latest changes in your doc. Please stay on your current note if you want to keep them.",
       "exit_confirmation_title": "Abandon your changes?",
       "exit_confirmation_leave": "Leave without saving",
-      "exit_confirmation_cancel": "Cancel"
+      "exit_confirmation_cancel": "Cancel",
+      "read_only": "This note is in read-only mode."
     },
     "List": {
       "latest_notes": "Latest Notes",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -16,7 +16,8 @@
       "exit_confirmation_message": "La sauvegarde automatique n'a pas encore pris en compte vos dernières modifications. Merci de retourner sur votre note pour ne pas les perdre.",
       "exit_confirmation_title": "Abandonner les modifications ?",
       "exit_confirmation_leave": "Quitter sans sauvegarder",
-      "exit_confirmation_cancel": "Retour"
+      "exit_confirmation_cancel": "Retour",
+      "read_only": "Cette note est en mode lecture-seule."
     },
     "List": {
       "latest_notes": "Notes récentes",


### PR DESCRIPTION
This was introduced in #145, the string was hard-coded (but it was the right text instead of a placeholder, so I missed it 😬)