### PR TITLE
fix: Don't crash when the locale is not supported

### DIFF
--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -3,7 +3,7 @@ import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import 'cozy-ui/dist/cozy-ui.utils.min.css'
 import 'cozy-ui/transpiled/react/stylesheet.css'
 import 'cozy-sharing/dist/stylesheet.css'
-import 'styles'
+import 'styles/index.css'
 
 import React from 'react'
 import ReactDOM from 'react-dom'
@@ -24,7 +24,6 @@ import {
 
 const manifest = require('../../../manifest.webapp')
 
-let appLocale
 const locales = {
   en: {
     react: require('react-intl/locale-data/en'),
@@ -35,10 +34,8 @@ const locales = {
     atlaskit: require('@atlaskit/editor-core/dist/cjs/i18n/fr').default
   }
 }
-addLocaleData(locales.en.react)
-addLocaleData(locales.fr.react)
 
-const renderApp = function(client, isPublic) {
+const renderApp = function(appLocale, client, isPublic) {
   const App = require('components/app').default
 
   render(
@@ -66,7 +63,7 @@ const renderApp = function(client, isPublic) {
 }
 
 // initial rendering of the application
-document.addEventListener('DOMContentLoaded', () => {
+export const initApp = () => {
   const data = getDataset()
 
   const appIcon = getDataOrDefault(
@@ -81,7 +78,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const appSlug = getDataOrDefault(data.cozyAppSlug, manifest.slug)
   const appVersion = getDataOrDefault(data.cozyAppVersion, manifest.version)
 
-  appLocale = getDataOrDefault(data.cozyLocale, 'en')
+  const supportedLocales = ['en', 'fr']
+
+  addLocaleData(locales.en.react)
+  addLocaleData(locales.fr.react)
+
+  const userLocale = getDataOrDefault(data.cozyLocale, 'en')
+  const appLocale = supportedLocales.includes(userLocale) ? userLocale : 'en'
 
   const protocol = window.location ? window.location.protocol : 'https:'
 
@@ -121,5 +124,7 @@ document.addEventListener('DOMContentLoaded', () => {
     })
   }
 
-  renderApp(client, isPublic)
-})
+  renderApp(appLocale, client, isPublic)
+}
+
+document.addEventListener('DOMContentLoaded', initApp)

--- a/src/targets/browser/index.spec.jsx
+++ b/src/targets/browser/index.spec.jsx
@@ -1,0 +1,31 @@
+import { initApp } from './index'
+import { render } from 'react-dom'
+import { getDataset } from 'lib/initFromDom'
+
+jest.mock('lib/initFromDom', () => ({
+  ...jest.requireActual('lib/initFromDom'),
+  getDataset: jest.fn().mockReturnValue({})
+}))
+
+jest.mock('react-dom', () => ({
+  ...jest.requireActual('react-dom'),
+  render: jest.fn()
+}))
+
+describe('app init', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('loads with the users locale', () => {
+    getDataset.mockReturnValue({ cozyLocale: 'fr' })
+    initApp()
+    expect(render.mock.calls[0][0]).toMatchObject({ props: { lang: 'fr' } })
+  })
+
+  it('falls back to a supported locale', () => {
+    getDataset.mockReturnValue({ cozyLocale: 'made-up-locale' })
+    initApp()
+    expect(render.mock.calls[0][0]).toMatchObject({ props: { lang: 'en' } })
+  })
+})


### PR DESCRIPTION
The Notes app was crashing when using a locale that wasn't supported (for example spanish). This PR makes the app default to a supported locale in that case.