### PR TITLE
Feat/upgrade schema

### DIFF
--- a/src/hooks/useNote.spec.js
+++ b/src/hooks/useNote.spec.js
@@ -1,0 +1,46 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+import useNote from './useNote'
+import { getSchemaVersion } from 'lib/collab/schema'
+
+jest.mock('lib/collab/schema', () => ({
+  ...jest.requireActual('lib/collab/schema'),
+  getSchemaVersion: jest.fn()
+}))
+describe('useNote', () => {
+  const mockedServiceClient = {
+    getDoc: jest.fn(),
+    updateSchema: jest.fn()
+  }
+  it('does not update the schema if not needed', async () => {
+    getSchemaVersion.mockReturnValue(0)
+    mockedServiceClient.getDoc.mockResolvedValue({
+      schemaVersion: 0,
+      title: 'My Title'
+    })
+    const { waitForNextUpdate } = renderHook(() =>
+      useNote({ serviceClient: mockedServiceClient, noteId: 1 })
+    )
+    await act(() => waitForNextUpdate())
+    expect(mockedServiceClient.getDoc).toHaveBeenCalled()
+    expect(mockedServiceClient.updateSchema).not.toHaveBeenCalled()
+  })
+
+  it('calls updateSchema if the doc schema is not the current schema for the app', async () => {
+    const NEW_SCHEMA_VERSION = 1
+    getSchemaVersion.mockReturnValue(NEW_SCHEMA_VERSION)
+    mockedServiceClient.getDoc.mockResolvedValue({
+      schemaVersion: 0,
+      title: 'My Title'
+    })
+    mockedServiceClient.updateSchema.mockResolvedValue({
+      schemaVersion: NEW_SCHEMA_VERSION,
+      title: 'My Title'
+    })
+    const { waitForNextUpdate } = renderHook(() =>
+      useNote({ serviceClient: mockedServiceClient, noteId: 1 })
+    )
+    await act(() => waitForNextUpdate())
+    expect(mockedServiceClient.getDoc).toHaveBeenCalled()
+    expect(mockedServiceClient.updateSchema).toHaveBeenCalled()
+  })
+})

--- a/src/lib/collab/channel.js
+++ b/src/lib/collab/channel.js
@@ -213,6 +213,9 @@ export class Channel {
     this.service.onTelepointerUpdated(noteId, payload => {
       this.emit('telepointer', payload)
     })
+    this.service.onSchemaUpdated(noteId, () => {
+      this.emit('schemaupdated')
+    })
     this.emit('connected', { version, doc, updatedAt })
   }
 

--- a/src/lib/collab/channel.spec.js
+++ b/src/lib/collab/channel.spec.js
@@ -13,7 +13,8 @@ const service = {
   onTelepointerUpdated: jest.fn(),
   join: jest.fn(),
   getSteps: jest.fn(),
-  pushTelepointer: jest.fn()
+  pushTelepointer: jest.fn(),
+  onSchemaUpdated: jest.fn()
 }
 
 describe('Channel', () => {
@@ -425,6 +426,18 @@ describe('Channel', () => {
       expect(service.onTelepointerUpdated).toHaveBeenCalledTimes(1)
       const callback = service.onTelepointerUpdated.mock.calls[0][1]
       callback(payload)
+    })
+
+    it('emits "schemaupdated" if the schema has been updated on the server', async done => {
+      const channel = new Channel(config, service)
+      channel.on('schemaupdated', () => {
+        expect(true).toBe(true)
+        done()
+      })
+      await channel.connect(version, doc)
+      expect(service.onSchemaUpdated).toHaveBeenCalledTimes(1)
+      const callback = service.onSchemaUpdated.mock.calls[0][1]
+      callback()
     })
 
     it('emit "connected"', async done => {

--- a/src/lib/collab/provider.js
+++ b/src/lib/collab/provider.js
@@ -70,6 +70,7 @@ export class CollabProvider {
     })
     this.channel.on('data', this.onReceiveData)
     this.channel.on('telepointer', this.onReceiveTelepointer)
+    this.channel.on('schemaupdated', this.onReceiveSchemaUpdated)
     this.channel.on('needcatchup', () => this.catchup())
     const state = getState()
     const doc = jsonTransformer.encode(state.doc)
@@ -285,7 +286,13 @@ export class CollabProvider {
     this.updateParticipant(sessionId, data.timestamp)
     this.emit('telepointer', data)
   }
-
+  /**
+   * We receive an update of the schema from the server
+   * We reload the page
+   */
+  onReceiveSchemaUpdated = () => {
+    window.location.reload(true)
+  }
   updateParticipant(sessionId, timestamp) {
     const userId = this.serviceClient.getUserId(sessionId)
     const participant = getParticipant({ userId, sessionId })

--- a/src/lib/collab/provider.spec.js
+++ b/src/lib/collab/provider.spec.js
@@ -27,7 +27,8 @@ const service = {
   onTelepointerUpdated: jest.fn(),
   join: jest.fn(),
   getSteps: jest.fn(),
-  pushTelepointer: jest.fn()
+  pushTelepointer: jest.fn(),
+  onSchemaUpdated: jest.fn()
 }
 const config = { noteId, version, channel, updatedAt }
 const configWithoutChannel = { noteId, version, updatedAt }

--- a/src/lib/collab/schema.js
+++ b/src/lib/collab/schema.js
@@ -28,6 +28,14 @@ import { Schema } from 'prosemirror-model'
 
 //https://github.com/cozy/cozy-notes/pull/2/commits/202e529cdb1e71996c2cab43057984c9f885b61a
 
+// if you edit the schema, please upgrade this schemaVersion
+
+export const schemaVersion = 1
+
+export const getSchemaVersion = () => {
+  return schemaVersion
+}
+
 export const nodes = [
   [
     'date',
@@ -740,8 +748,6 @@ export const schemaObject = {
   nodes: orderedToObject(nodes),
   marks: orderedToObject(marks)
 }
-
-export const schemaVersion = 1
 
 const schema = new Schema(schemaObject)
 

--- a/src/lib/collab/schema.js
+++ b/src/lib/collab/schema.js
@@ -741,6 +741,8 @@ export const schemaObject = {
   marks: orderedToObject(marks)
 }
 
+export const schemaVersion = 1
+
 const schema = new Schema(schemaObject)
 
 export default schema

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,7 +1,7 @@
 import get from 'lodash/get'
 import { generateWebLink } from 'cozy-ui/transpiled/react/AppLinker'
 import { getDataset, getDataOrDefault } from './initFromDom'
-import { schemaOrdered } from 'lib/collab/schema'
+import { schemaOrdered, schemaVersion } from 'lib/collab/schema'
 import { models } from 'cozy-client'
 
 import manifest from '../../manifest.webapp'
@@ -156,7 +156,10 @@ export function createNoteDocument(client) {
       type: 'io.cozy.notes.documents',
       attributes: {
         title: '',
-        schema: schemaOrdered
+        schema: {
+          ...schemaOrdered,
+          version: schemaVersion
+        }
       }
     }
   })

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -336,7 +336,7 @@ html body .note-editor-container .akEditor .ak-editor-panel[data-panel-type=info
     background-color: #EEF5FD ; /* var(--dodgerBlue) * 0.8 */
 }
 html body .note-editor-container .akEditor .ak-editor-panel[data-panel-type=info] .ak-editor-panel__icon {
-    color: 3F7FE9;
+    color: #3F7FE9;
 }
 html body .note-editor-container .akEditor .ak-editor-panel[data-panel-type=success] {
     background-color: #F0FAF4 ; /* var(--emerald) * 0.8 */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -19,16 +19,22 @@ html {
     --note-title2-fs: calc(1.333 * var(--note-base-size));
     --note-title3-fs: var(--note-base-size);
     --note-title4-fs: var(--note-base-size);
+    --note-title5-fs: calc((var(--note-base-size) * 0.89));
+    --note-title6-fs: calc((var(--note-base-size) * 0.78));
     --note-title0-lh: 1.2;
     --note-title1-lh: 1.3;
     --note-title2-lh: 1.4;
     --note-title3-lh: var(--note-base-lh);
     --note-title4-lh: var(--note-base-lh);
+    --note-title5-lh: 1.55;
+    --note-title6-lh: 1.6;
     --note-title0-color: var(--note-base-color);
     --note-title1-color: var(--note-base-color);
     --note-title2-color: var(--note-base-color);
     --note-title3-color: var(--note-base-color);
     --note-title4-color: var(--coolGrey);
+    --note-title5-color: var(--coolGrey);
+    --note-title6-color: var(--coolGrey);
     --note-border-radius: 8px;
     --note-header-height: 3rem;
     --note-header-margin-left: 7rem;
@@ -219,12 +225,22 @@ html body .note-editor-container .akEditor h3 {
     line-height: var(--note-title3-lh) !important;
     color: var(--note-title3-color);
 }
-html body .note-editor-container .akEditor h4,
-html body .note-editor-container .akEditor h5,
-html body .note-editor-container .akEditor h6 {
+html body .note-editor-container .akEditor h4 {
     font-size: var(--note-title4-fs) !important;
     line-height: var(--note-title4-lh) !important;
     color: var(--note-title4-color);
+}
+
+html body .note-editor-container .akEditor h5 {
+    font-size: var(--note-title5-fs) !important;
+    line-height: var(--note-title5-lh) !important;
+    color: var(--note-title5-color);
+}
+
+html body .note-editor-container .akEditor h6 {
+    font-size: var(--note-title6-fs) !important;
+    line-height: var(--note-title6-lh) !important;
+    color: var(--note-title6-color);
 }
 
 /* Titres dans la dropdown de la barre d'outils */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -249,10 +249,6 @@ html body .note-editor-container .akEditor > div:first-child  h5,
 html body .note-editor-container .akEditor > div:first-child  h6 {
     margin-bottom: 0;
 }
-.akEditor > div:first-child /* sc-bYwvMP */ > div:first-child > div:first-child > div:first-child /* sc-gmeYpB */ > span:first-child /* sc-kTUwUJ */ > div:first-child /* sc-kZmsYB */  div[role=group] > div:nth-child(6),
-.akEditor > div:first-child /* sc-bYwvMP */ > div:first-child > div:first-child > div:first-child /* sc-gmeYpB */ > span:first-child /* sc-kTUwUJ */ > div:first-child /* sc-kZmsYB */  div[role=group] > div:nth-child(7) {
-    display: none;
-}
 
 
 /* spacing between blocks */


### PR DESCRIPTION
Add to Notes the capability to upgrade a schema for a Note. Useful when we add new plugins or upgrade Altaskit plugins.

- Store the schema's version in `metadata.schema.version` when we create a note 
- If the schema of the note is different from the one of the app, we call the stack to update the schema 
- Handle the case of a shared note using realtime to reload the app 