### PR TITLE
feat(NoteRow): add button role

### DIFF
--- a/src/components/notes/List/NoteRow.jsx
+++ b/src/components/notes/List/NoteRow.jsx
@@ -41,14 +41,25 @@ const NoteRow = ({ note, f, t, client }) => {
 
   const menuTriggerRef = React.createRef()
 
+  const goToNote = async () => {
+    const url = await generateReturnUrlToNotesIndex(client, note)
+    window.location.href = url
+  }
+
+  const handleKeyDown = e => {
+    if (e.key === 'Enter') {
+      goToNote()
+    }
+  }
+
   return (
     <>
       <TableRow
         className={`u-c-pointer ${styles.tableRow}`}
-        onClick={async () => {
-          const url = await generateReturnUrlToNotesIndex(client, note)
-          window.location.href = url
-        }}
+        role="button"
+        tabIndex="0"
+        onKeyDown={handleKeyDown}
+        onClick={goToNote}
       >
         <TableCell
           className={`${styles.tableCellName} u-flex u-flex-items-center u-fz-medium`}


### PR DESCRIPTION
II use the [vimium](https://addons.mozilla.org/fr/firefox/addon/vimium-ff/) browser
extension that allows me to highlight interactive elements when pressing the
`f` key. When I pressed this key while using cozy-notes, I couldn't reach the
notes list items.

I'm no a11y expert, but I found the reason was the following:

The whole row has an onClick handler that redirects to the note editor
when the user clicks the row. But since the rendered element is a div,
it was not properly seen as a button by the browser

Adding a button role and a tabIndex make it accessible. And to be complete, I
added a onKeyDown handler that redirects to the note when the user presses the
Enter key.
