### PR TITLE
fix: Don't update the schema if readOnly

### DIFF
--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -36,7 +36,12 @@ export default function Editor(props) {
     cozyClient
   })
   const serviceClient = useServiceClient({ userId, userName, cozyClient })
-  const { loading, title, doc, setTitle } = useNote({ serviceClient, noteId })
+  const { loading, title, doc, setTitle } = useNote({
+    serviceClient,
+    noteId,
+    readOnly
+  })
+
   const returnUrl = useReturnUrl({
     returnUrl: props.returnUrl,
     cozyClient,

--- a/src/hooks/useNote.js
+++ b/src/hooks/useNote.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { getSchemaVersion, schemaOrdered } from 'lib/collab/schema'
 
-function useNote({ serviceClient, noteId }) {
+function useNote({ serviceClient, noteId, readOnly }) {
   // `docId` is the id of the note for which we have a state.
   // `noteId` is the id of the requested note.
   const [docId, setDocId] = useState(noteId)
@@ -20,7 +20,7 @@ function useNote({ serviceClient, noteId }) {
           // not the on for the Note. We need to update it in order
           // to be able to use the latest features brought by
           // the new schema
-          if (doc.schemaVersion !== getSchemaVersion()) {
+          if (!readOnly && doc.schemaVersion !== getSchemaVersion()) {
             doc = await serviceClient.updateSchema(docId, schemaOrdered)
           }
           setTitle(doc.title || '')


### PR DESCRIPTION
Previously, we tried to update the note's schema, even if the note was opened in read only. Since readOnly doesn't have the permission to update the schema an error was dispatched. 

So let's not update the schema if the note is opened in read only. 