### PR TITLE
fix: force editor-tables resolution to editor-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "utf-8-validate": "5.0.5"
   },
   "resolutions": {
-    "prosemirror-model": "1.11.0"
+    "prosemirror-model": "1.11.0",
+    "cozy-editor-core/@atlaskit/editor-tables": "1.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,10 +459,10 @@
     "@babel/runtime" "^7.0.0"
     styled-components "^3.2.6"
 
-"@atlaskit/editor-tables@^1.1.0":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@atlaskit/editor-tables/-/editor-tables-1.1.5.tgz#a695d0cfd358ddaf396ee6cb6e1a3633016e7670"
-  integrity sha512-/XpylnkYRvEFu0CbFRxRUBhWmf4ZSIR58gvc8YvGpRvpNP4E8SBprp1BSjef54ZOJyzrN7yB3NhswUOloT0sng==
+"@atlaskit/editor-tables@1.1.3", "@atlaskit/editor-tables@^1.1.0":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@atlaskit/editor-tables/-/editor-tables-1.1.3.tgz#a86f54991cd49b8c37e434940b332935962bf6f5"
+  integrity sha512-7NFGrSHB36oPc0phcJhDShjHqE35dZnz2uE+NhFMYBqua1l6LwEdf5BnAGrTNSJ1YgRqOOscHg1Du9SBKLkgkQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     prosemirror-keymap "1.1.4"


### PR DESCRIPTION
https://trello.com/c/HUipo7Qa/50-retour-4-regression-je-narrive-plus-%C3%A0-cr%C3%A9er-des-tableaux-dans-les-notes-erreur-en-console-uncaught-typeerror-e-is-undefined

editor-core as we use it (v134.0.1) will break with editor-tables > 1.1.3. It was necessary to update the resolution of this dependency. I don't think this is a long term solution, best would be to update editor-core itself but unsure at the moment what problems would it create with cozy-stack