### PR TITLE
feat: handle invalid file uploads

### DIFF
--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -83,7 +83,7 @@ function EditorView(props) {
           appearance="full-page"
           placeholder={t('Notes.EditorView.main_placeholder')}
           shouldFocus={!readOnly}
-          legacyImageUploadProvider={imageUploadProvider(collabProvider)}
+          legacyImageUploadProvider={imageUploadProvider(collabProvider, t)}
           contentComponents={
             <WithEditorActions
               render={() => (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -89,7 +89,9 @@
     "unshared_text": "The owner may have revoked this sharing. You can no longer edit a note at this address.",
     "loading_error_title": "The note couldn't be loaded",
     "loading_error_text_noReturnUrl": "The note may not exists anymore, or our servers may have a temporary glitch. Please try again later.",
-    "loading_error_text_returnUrl": "The note may not exists anymore, or our servers may have a temporary glitch. Please go <a href='%{url}'>back</a> and try again later."
+    "loading_error_text_returnUrl": "The note may not exists anymore, or our servers may have a temporary glitch. Please go <a href='%{url}'>back</a> and try again later.",
+    "422": "Only images are accepted",
+    "unknown_error": "An unexpected error occured"
   },
   "manifest": {
     "short_description": "Cozy Notes is your personal and collaborative note-taking application.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -89,7 +89,9 @@
     "unshared_text": "Le propriétaire a peut-être révoqué ce partage. Vous ne pouvez plus éditer de note à cette adresse.",
     "loading_error_title": "La note n'a pas pu être chargée",
     "loading_error_text_noReturnUrl": "Cette note n'existe peut-être plus, ou nos serveurs ont peut-être un moment d'égarrement. Merci de retenter plus tard.",
-    "loading_error_text_returnUrl": "Cette note n'existe peut-être plus, ou nos serveurs ont peut-être un moment d'égarrement. Merci revenir <a href='%{url}'>en arrière</a> et de retenter plus tard."
+    "loading_error_text_returnUrl": "Cette note n'existe peut-être plus, ou nos serveurs ont peut-être un moment d'égarrement. Merci revenir <a href='%{url}'>en arrière</a> et de retenter plus tard.",
+    "422": "Seules les images sont acceptées",
+    "unknown_error": "Une erreur inattendue s'est produite"
   },
   "manifest": {
     "short_description": "Cozy Notes est votre application de prise de notes personnelles et collaboratives.",

--- a/src/types/declarations.d.ts
+++ b/src/types/declarations.d.ts
@@ -1,0 +1,3 @@
+declare module 'cozy-ui/transpiled/react/Alerter' {
+  function error(error: string): void
+}

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,0 +1,6 @@
+export interface CozyStackError {
+  status: number
+  title: string
+  detail: string
+  source: { parameter: string }
+}

--- a/src/types/guards.ts
+++ b/src/types/guards.ts
@@ -1,0 +1,7 @@
+import { CozyStackError } from './errors'
+
+export function isCozyStackError(
+  error: CozyStackError | unknown
+): error is CozyStackError {
+  return (error as CozyStackError).status !== undefined
+}


### PR DESCRIPTION
Related to https://trello.com/c/y4QmVMRU/40-%F0%9F%93%9D-notes-affichage-derreur-si-upload-de-type-de-fichier-non-image

It is impossible to disallow the user to upload any kind of invalid file if he really wants to. The backend will error on such files. Thus, we will rely on it, there's no real gain to validate front-end side. That way we just wait to see if the upload failed with a 422, that will assure us the file is unprocessable. We just have to display an error alert for good UX as a way to handle this error.