### PR TITLE
feat: Improve loading states

### DIFF
--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useEffect, useMemo } from 'react'
+import React, { useCallback, useRef, useEffect, useMemo, useState } from 'react'
 
 import { Editor, WithEditorActions } from '@atlaskit/editor-core'
 
@@ -6,6 +6,8 @@ import { MainTitle } from 'cozy-ui/transpiled/react/Text'
 import Textarea from 'cozy-ui/transpiled/react/Textarea'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import useEventListener from 'cozy-ui/transpiled/react/hooks/useEventListener'
+import Overlay from 'cozy-ui/transpiled/react/Overlay'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import editorConfig from 'components/notes/editor_config'
 import HeaderMenu from 'components/header_menu'
@@ -65,8 +67,15 @@ function EditorView(props) {
 
   useEventListener(titleEl.current, 'blur', onTitleBlur)
 
+  const [isUploading, setUploading] = useState(false)
+
   return (
     <article className={styles['note-article']}>
+      {isUploading && (
+        <Overlay>
+          <Spinner size="xxlarge" middle />
+        </Overlay>
+      )}
       <style>#coz-bar {'{ display: none }'}</style>
       <HeaderMenu
         left={leftComponent}
@@ -83,7 +92,11 @@ function EditorView(props) {
           appearance="full-page"
           placeholder={t('Notes.EditorView.main_placeholder')}
           shouldFocus={!readOnly}
-          legacyImageUploadProvider={imageUploadProvider(collabProvider, t)}
+          legacyImageUploadProvider={imageUploadProvider(
+            collabProvider,
+            t,
+            setUploading
+          )}
           contentComponents={
             <WithEditorActions
               render={() => (

--- a/src/constants/interface.ts
+++ b/src/constants/interface.ts
@@ -1,0 +1,1 @@
+export const TOASTER_DURATION = 4000

--- a/src/lib/image-upload-provider.ts
+++ b/src/lib/image-upload-provider.ts
@@ -21,7 +21,8 @@ interface CollabProvider {
 
 export const imageUploadProvider = (
   collabProvider: CollabProvider,
-  t: (error: string) => string
+  t: (error: string) => string,
+  setUploading: (set: boolean) => void
 ): Promise<ImageUploadProvider> =>
   Promise.resolve<ImageUploadProvider>((_event, insertImageFn) => {
     const inputElement = document.createElement(ElementType.Input)
@@ -46,6 +47,8 @@ export const imageUploadProvider = (
         if (!processedFile) throw Error(Errors.FileNotProcessable)
 
         try {
+          setUploading(true)
+
           const {
             data: { id: src }
           } = await collabProvider.serviceClient.postImage(
@@ -65,6 +68,8 @@ export const imageUploadProvider = (
             ),
             { duration: TOASTER_DURATION }
           )
+        } finally {
+          setUploading(false)
         }
       }
     })

--- a/src/lib/image-upload-provider.ts
+++ b/src/lib/image-upload-provider.ts
@@ -3,6 +3,7 @@ import { ElementType, Errors, EventType, InputType } from 'constants/strings'
 import { processFile } from 'lib/utils/process-file'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import { isCozyStackError } from 'types/guards'
+import { TOASTER_DURATION } from 'constants/interface'
 
 interface CollabProvider {
   config: {
@@ -61,7 +62,8 @@ export const imageUploadProvider = (
               isCozyStackError(error)
                 ? `Error.${error.status}`
                 : 'Error.unknown_error'
-            )
+            ),
+            { duration: TOASTER_DURATION }
           )
         }
       }

--- a/src/types/declarations.d.ts
+++ b/src/types/declarations.d.ts
@@ -1,3 +1,10 @@
 declare module 'cozy-ui/transpiled/react/Alerter' {
-  function error(error: string): void
+  function error(
+    error: string,
+    options?: {
+      duration?: number
+      buttonText?: string
+      buttonAction?: (...args: unknown[]) => void
+    }
+  ): void
 }


### PR DESCRIPTION
This is a quick fix to improve loading states when uploading large images. It will block the page and show a 0.5 opacity black overlay with a spinner in its center. Main issue is for fast uploads, it will show up briefly. But for now it's better than having a page freely editable while we're actually waiting for an async op in a sync way to update the prosemirror tree.