### PR TITLE
feat: Add cozy-to-cozy sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ yarn-error.log
 build/
 build.*/
 
+# Stack
+storage/
+
 # Coverage
 coverage/
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,9 @@
+# 1.18.0
+
+## ✨ Features
+
+* Add Cozy-to-Cozy sharing
+
 # 1.17.0
 
 ## 🐛 Bug Fixes

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -51,7 +51,7 @@
     },
     "contacts": {
       "type": "io.cozy.contacts",
-      "verbs": ["GET"]
+      "verbs": ["GET", "POST"]
     },
     "groups": {
       "type": "io.cozy.contacts.groups",

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -27,6 +27,11 @@
       "folder": "/",
       "index": "index.html",
       "public": true
+    },
+    "/preview": {
+      "folder": "/",
+      "index": "index.html",
+      "public": true
     }
   },
   "permissions": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "cozy-flags": "2.7.2",
     "cozy-realtime": "3.13.0",
     "cozy-scripts": "eslint7",
-    "cozy-sharing": "3.4.2",
+    "cozy-sharing": "3.7.0",
     "cozy-ui": "51.6.0",
     "eslint-config-cozy-app": "1.6.0",
     "lodash": "^4.17.15",

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -4,6 +4,7 @@ import { Route, Switch, HashRouter, withRouter } from 'react-router-dom'
 import { useClient } from 'cozy-client'
 import useClientErrors from 'cozy-client/dist/hooks/useClientErrors'
 
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import { Layout, Main, Content } from 'cozy-ui/transpiled/react/Layout'
 import { Sprite as IconSprite } from 'cozy-ui/transpiled/react/Icon'
@@ -92,6 +93,7 @@ const App = ({ isPublic }) => {
   const client = useClient()
   const { isMobile } = useBreakpoints
   const { ClientErrors } = useClientErrors()
+  const { t } = useI18n()
 
   const appName = isMobile
     ? getDataOrDefault(client.getInstanceOptions().app.name, manifest.name)
@@ -116,7 +118,7 @@ const App = ({ isPublic }) => {
             </Content>
           </Main>
           <IconSprite />
-          <Alerter />
+          <Alerter t={t} />
           <FlagSwitcher />
         </Layout>
       </HashRouter>

--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -8,6 +8,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import useEventListener from 'cozy-ui/transpiled/react/hooks/useEventListener'
 import Overlay from 'cozy-ui/transpiled/react/Overlay'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import { SharingBannerPlugin } from 'cozy-sharing'
 
 import editorConfig from 'components/notes/editor_config'
 import HeaderMenu from 'components/header_menu'
@@ -97,6 +98,7 @@ function EditorView(props) {
             t,
             setUploading
           )}
+          primaryToolbarComponents={<SharingBannerPlugin />}
           contentComponents={
             <WithEditorActions
               render={() => (

--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -8,7 +8,6 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import useEventListener from 'cozy-ui/transpiled/react/hooks/useEventListener'
 import Overlay from 'cozy-ui/transpiled/react/Overlay'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
-import { SharingBannerPlugin } from 'cozy-sharing'
 
 import editorConfig from 'components/notes/editor_config'
 import HeaderMenu from 'components/header_menu'
@@ -98,7 +97,7 @@ function EditorView(props) {
             t,
             setUploading
           )}
-          primaryToolbarComponents={<SharingBannerPlugin />}
+          primaryToolbarComponents={props.primaryToolbarComponents}
           contentComponents={
             <WithEditorActions
               render={() => (

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useContext, useCallback, useRef } from 'react'
 import PropTypes from 'prop-types'
 
 import { useClient } from 'cozy-client'
-import { SharingBannerPlugin } from 'cozy-sharing'
 
 import EditorView from 'components/notes/editor-view'
 import EditorCorner from 'components/notes/EditorCorner'
@@ -93,7 +92,6 @@ export default function Editor(props) {
   } else if (doc) {
     return (
       <>
-        <SharingBannerPlugin />
         <EditorView
           bannerRef={bannerRef}
           readOnly={readOnly}

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useContext, useCallback, useRef } from 'react'
 import PropTypes from 'prop-types'
 
 import { useClient } from 'cozy-client'
+import { SharingBannerPlugin } from 'cozy-sharing'
 
 import EditorView from 'components/notes/editor-view'
 import EditorCorner from 'components/notes/EditorCorner'
@@ -92,6 +93,7 @@ export default function Editor(props) {
   } else if (doc) {
     return (
       <>
+        <SharingBannerPlugin />
         <EditorView
           bannerRef={bannerRef}
           readOnly={readOnly}

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useContext, useCallback, useRef } from 'react'
 import PropTypes from 'prop-types'
 
 import { useClient } from 'cozy-client'
+import { SharingBannerPlugin } from 'cozy-sharing'
 
 import EditorView from 'components/notes/editor-view'
 import EditorCorner from 'components/notes/EditorCorner'
@@ -17,6 +18,7 @@ import useTitleChanges from 'hooks/useTitleChanges'
 import useForceSync from 'hooks/useForceSync'
 import useReturnUrl from 'hooks/useReturnUrl'
 import useUser from 'hooks/useUser'
+import { usePreview } from 'hooks/usePreview'
 import { useDebugValue } from 'lib/debug'
 
 import useConfirmExit from 'cozy-ui/transpiled/react/hooks/useConfirmExit'
@@ -77,6 +79,8 @@ export default function Editor(props) {
     cancelLabel: t('Notes.Editor.exit_confirmation_cancel')
   })
 
+  const isPreview = usePreview(window.location.pathname)
+
   useDebugValue('client', cozyClient)
   useDebugValue('notes.service', serviceClient)
   useDebugValue('notes.collabProvider', collabProvider)
@@ -111,6 +115,7 @@ export default function Editor(props) {
           rightComponent={
             <EditorCorner doc={doc} isPublic={isPublic} isReadOnly={readOnly} />
           }
+          primaryToolbarComponents={isPreview ? <SharingBannerPlugin /> : null}
         />
         <SavingIndicator
           collabProvider={collabProvider}

--- a/src/components/notes/sharing.jsx
+++ b/src/components/notes/sharing.jsx
@@ -7,27 +7,35 @@ import styles from 'components/notes/sharing.styl'
 
 export default function SharingWidget(props) {
   const client = useClient()
-
   const file = useFileWithPath({ cozyClient: client, file: props.file })
-  const noteId = file && file.id
-
   const [showModal, setShowModal] = useState(false)
   const onClick = useCallback(() => setShowModal(!showModal), [showModal])
   const onClose = useCallback(() => setShowModal(false), [])
 
+  if (!file) return null
+
+  const {
+    id: noteId,
+    attributes: { name }
+  } = file
+
   return (
-    (file && (
-      <>
-        <ShareButton
-          theme="primary"
-          docId={noteId}
-          onClick={onClick}
-          extension="narrow"
-          className={styles['sharing-button']}
+    <>
+      <ShareButton
+        theme="primary"
+        docId={noteId}
+        onClick={onClick}
+        extension="narrow"
+        className={styles['sharing-button']}
+      />
+      {showModal && (
+        <ShareModal
+          document={{ ...file, name }}
+          documentType="Files"
+          onClose={onClose}
+          sharingDesc={name}
         />
-        {showModal && <ShareModal document={file} onClose={onClose} />}
-      </>
-    )) ||
-    null
+      )}
+    </>
   )
 }

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -33,3 +33,5 @@ export enum CozyDoctypes {
 export enum Slugs {
   Drive = 'drive'
 }
+
+export const SHARING_LOCATION = '/preview'

--- a/src/hooks/usePreview.ts
+++ b/src/hooks/usePreview.ts
@@ -1,0 +1,13 @@
+import { SHARING_LOCATION } from 'constants/strings'
+import { getPublicSharecode } from 'lib/initFromDom'
+import { useState, useEffect } from 'react'
+
+export const usePreview = (pathname: string): boolean => {
+  const [shouldDisplay, setDisplay] = useState(false)
+
+  useEffect(() => {
+    setDisplay(SHARING_LOCATION === pathname && !!getPublicSharecode())
+  }, [pathname])
+
+  return shouldDisplay
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -38,7 +38,7 @@ html {
     --note-border-radius: 8px;
     --note-header-height: 3rem;
     --note-header-margin-left: 7rem;
-    --note-header-margin-right: 10rem;
+    --note-header-margin-right: 12rem;
     color: var(--note-base-color);
 }
 @media (max-width: 800px) {
@@ -85,19 +85,20 @@ html .akEditor > div:first-child > div:first-child {
     overflow: visible; /* important for dropdowns */
 }
 
-/* avatars */
+/* second header block (contains sharing banner) */
 html .akEditor > div:first-child > div:first-child + div {
-    display: none;
+    display: block;
+    position: absolute;
+    top: 100%;
+    transform: translateX(calc(-1 * var(--note-header-margin-left)));
+    width: calc(100% + var(--note-header-margin-left) + var(--note-header-margin-right));
 }
-
-
 
 /* icon for text color in the toolbar was not correctly aligned */
 .sc-gxMtzJ {
     position: relative;
     top: 0.2rem;
 }
-
 
 /* auto size for the toolbar ... sizes for 5+5rem as margin */
 [data-testid="ak-editor-main-toolbar"] > div > div:nth-child(2) {
@@ -168,7 +169,7 @@ html .akEditor > div:first-child > div:first-child + div {
 .note-header-menu--editing {
   display: flex;
   justify-content: space-between;
-  padding: 0 1rem;
+  padding: 0 1rem; 
   margin: 0;
   align-items: center;
   box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.08), 0 2px 4px 0 rgba(50, 54, 63, 0.08);
@@ -178,7 +179,6 @@ html .akEditor > div:first-child > div:first-child + div {
 }
 .note-header-menu--editing .page-header-menu--left {
   display: flex;
-  flex-grow: 1;
   align-items: center;
 }
 .note-header-menu--editing .page-header-menu--right {
@@ -202,7 +202,7 @@ html .ProseMirror {
 }
 
 /* Titres */
-html body .note-editor-container .akEditor p,
+html body .note-editor-container .ak-editor-content-area p,
 html body .note-editor-container .akEditor li {
     font-size: var(--note-base-size) !important;
     line-height: var(--note-base-lh) !important;
@@ -252,7 +252,7 @@ html body .note-editor-container .akEditor > div:first-child  h6 {
 
 
 /* spacing between blocks */
-html body .note-editor-container .akEditor p,
+html body .note-editor-container .ak-editor-content-area p,
 html body .note-editor-container .akEditor ul,
 html body .note-editor-container .akEditor ol,
 html body .note-editor-container .akEditor blockquote,

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -3,7 +3,6 @@
     font-size: 1rem;
 }
 
-
 html {
     --documentMaxWidth: 48rem;
     --documentDividerColor: #D6D8DA;
@@ -37,15 +36,15 @@ html {
     --note-title6-color: var(--coolGrey);
     --note-border-radius: 8px;
     --note-header-height: 3rem;
-    --note-header-margin-left: 7rem;
-    --note-header-margin-right: 12rem;
     color: var(--note-base-color);
 }
+
 @media (max-width: 800px) {
     html {
         --documentPadding: var(--note-base-size);
     }
 }
+
 @media (max-width: 420px) {
     html {
         --note-base-size: 1rem;
@@ -64,34 +63,37 @@ html {
     z-index: 2;
     background-color: var(--white);
 }
+
 html .akEditor > div:first-child {
     position: sticky;
     top: 0;
     z-index: 3;
 }
+
 .note-editor-container {
     height: calc(100% - 48px);
 }
 
 /* prose mirror toolbar in the upper bar */
 html .akEditor > div:first-child {
-    margin-left: var(--note-header-margin-left);
-    margin-right: var(--note-header-margin-right);
     margin-bottom: 0;
-    height: var(--note-header-height);
+    flex-wrap: wrap;
+    height: auto;
+    box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.08), 0 2px 4px 0 rgba(50, 54, 63, 0.08);
 }
+
 html .akEditor > div:first-child > div:first-child {
     margin: auto;
     overflow: visible; /* important for dropdowns */
 }
 
-/* second header block (contains sharing banner) */
 html .akEditor > div:first-child > div:first-child + div {
     display: block;
-    position: absolute;
-    top: 100%;
-    transform: translateX(calc(-1 * var(--note-header-margin-left)));
-    width: calc(100% + var(--note-header-margin-left) + var(--note-header-margin-right));
+    width: 100%;
+}
+
+html .akEditor > div:first-child > div:first-child + div hr {
+    margin-bottom: 0;
 }
 
 /* icon for text color in the toolbar was not correctly aligned */
@@ -105,54 +107,57 @@ html .akEditor > div:first-child > div:first-child + div {
     width: 730px; /* full toolbar */
     max-width: 100%;
     margin: auto;
+    padding: 1rem 0;
 }
+
+[data-testid="ak-editor-main-toolbar"] + div {
+    height: calc(100% - 130px);
+}
+
 @media (max-width: 1023px) {
   html {
     --useless: auto;
    /* FIXME : without this block, the next rule is not taken into account */
   }
 }
+
 @media (max-width: 1023px) {
   html {
     --notes-share-button-label: none; /* do not display the label in sharing button */
-    --note-header-margin-left: 5rem; /* remove margin to leave space for the toolbar */
-    --note-header-margin-right: 5rem;
   }
 }
+
 @media (max-width: 810px) {
     html .akEditor > div:first-child > div:first-child > div:first-child > div:first-child {
         width: 480px; /* condensed view */
     }
 }
+
 @media (max-width: 740px) {
     html .akEditor > div:first-child > div:first-child > div:first-child > div:first-child {
         width: 390px; /* block style as icon */
     }
 }
+
 @media (max-width: 660px) {
     html .akEditor > div:first-child > div:first-child > div:first-child > div:first-child {
         width: 380px; /* merge ol and ul as dropdown */
     }
 }
+
 @media (max-width: 610px) {
     html .akEditor > div:first-child > div:first-child > div:first-child > div:first-child {
         width: 350px; /* left icons as dropdown */
     }
 }
+
 @media (max-width: 530px) {
     html .akEditor > div:first-child > div:first-child > div:first-child > div:first-child {
         width: 280px; /* more left icons as dropdown */
     }
 }
-@media (max-width: 480px) {
-    html {
-        --note-header-margin-left: 3rem;
-    }
-}
+
 @media (max-width: 375px) {
-    html {
-        --note-header-margin-left: 2.5rem;
-    }
     .page-header-menu--right {
         position: relative;
         left: 0.5rem;
@@ -167,21 +172,21 @@ html .akEditor > div:first-child > div:first-child + div {
 }
 
 .note-header-menu--editing {
-  display: flex;
-  justify-content: space-between;
-  padding: 0 1rem; 
-  margin: 0;
-  align-items: center;
-  box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.08), 0 2px 4px 0 rgba(50, 54, 63, 0.08);
-  z-index: 3;
-  height: var(--note-header-height);
-  margin-bottom: calc(0px - var(--note-header-height));
+  z-index: 4;
 }
+
 .note-header-menu--editing .page-header-menu--left {
+  top: 0.75rem;
+  left: 1rem;
+  position: absolute;
   display: flex;
   align-items: center;
 }
+
 .note-header-menu--editing .page-header-menu--right {
+  top: 1rem;
+  right: 1rem;
+  position: absolute;
   display: flex;
   align-items: center;
 }
@@ -192,6 +197,7 @@ html .note-editor-container {
     flex-direction: column;
     flex-grow: 1;
 }
+
 html .notes-list-container .page-header-menu {
     margin-left: 2rem;
     margin-right: 2rem;
@@ -208,6 +214,7 @@ html body .note-editor-container .akEditor li {
     line-height: var(--note-base-lh) !important;
     color: var(--note-base-color);
 }
+
 html body .note-editor-container .akEditor h1 {
     border-top: 1px solid var(--silver);
     padding-top: var(--note-block-spacing);
@@ -215,16 +222,19 @@ html body .note-editor-container .akEditor h1 {
     line-height: var(--note-title1-lh) !important;
     color: var(--note-title1-color);
 }
+
 html body .note-editor-container .akEditor h2 {
     font-size: var(--note-title2-fs) !important;
     line-height: var(--note-title2-lh) !important;
     color: var(--note-title2-color);
 }
+
 html body .note-editor-container .akEditor h3 {
     font-size: var(--note-title3-fs) !important;
     line-height: var(--note-title3-lh) !important;
     color: var(--note-title3-color);
 }
+
 html body .note-editor-container .akEditor h4 {
     font-size: var(--note-title4-fs) !important;
     line-height: var(--note-title4-lh) !important;
@@ -250,7 +260,6 @@ html body .note-editor-container .akEditor > div:first-child  h6 {
     margin-bottom: 0;
 }
 
-
 /* spacing between blocks */
 html body .note-editor-container .ak-editor-content-area p,
 html body .note-editor-container .akEditor ul,
@@ -268,6 +277,7 @@ html body .note-editor-container .akEditor h6 {
     margin-top: 0;
     margin-bottom: var(--note-block-spacing);
 }
+
 html body .note-editor-container .akEditor .ak-editor-panel__content > :last-child,
 html body .note-editor-container .akEditor li > * {
     margin-bottom: 0;
@@ -280,10 +290,12 @@ html body .note-editor-container .akEditor blockquote {
     border-left: 4px solid var(--silver);
     font-style: italic;
 }
+
 html body .note-editor-container .akEditor blockquote i,
 html body .note-editor-container .akEditor blockquote em {
     font-style: normal;
 }
+
 html body .note-editor-container .akEditor blockquote::before {
     display: none;
 }
@@ -298,37 +310,45 @@ html body .note-editor-container .akEditor hr {
 html body .note-editor-container .akEditor .tableView-content-wrap {
     margin-top: -1.8rem;
 }
+
 html body .note-editor-container .akEditor .pm-table-wrapper > table {
     border-collapse: separate;
     border-spacing: 0;
     border-width: 0;
 }
+
 html body .note-editor-container .akEditor .pm-table-wrapper > table td,
 html body .note-editor-container .akEditor .pm-table-wrapper > table th {
     border: 1px solid #C1C7D0;
     border-bottom-width: 0;
     border-right-width: 0;
 }
+
 html body .note-editor-container .akEditor .pm-table-wrapper > table tr:last-child td,
 html body .note-editor-container .akEditor .pm-table-wrapper > table tr:last-child th {
     border-bottom-width: 1px;
 }
+
 html body .note-editor-container .akEditor .pm-table-wrapper > table td:last-child,
 html body .note-editor-container .akEditor .pm-table-wrapper > table th:last-child {
     border-right-width: 1px;
 }
+
 html body .note-editor-container .akEditor tbody > tr:first-child > th:first-child,
 html body .note-editor-container .akEditor tbody > tr:first-child > td:first-child {
     border-top-left-radius: var(--note-border-radius);
 }
+
 html body .note-editor-container .akEditor tbody > tr:first-child > th:last-child,
 html body .note-editor-container .akEditor tbody > tr:first-child > td:last-child {
     border-top-right-radius: var(--note-border-radius);
 }
+
 html body .note-editor-container .akEditor tbody > tr:last-child > th:first-child,
 html body .note-editor-container .akEditor tbody > tr:last-child > td:first-child {
     border-bottom-left-radius: var(--note-border-radius);
 }
+
 html body .note-editor-container .akEditor tbody > tr:last-child > th:last-child,
 html body .note-editor-container .akEditor tbody > tr:last-child > td:last-child {
     border-bottom-right-radius: var(--note-border-radius);
@@ -374,8 +394,6 @@ html .akEditor {
     min-width: calc(320px - 2rem);
 }
 
-
-
 html .fabric-editor-popup-scroll-parent > div > div {
   margin: 0 auto;
   padding: 0;
@@ -398,13 +416,16 @@ html .fabric-editor-popup-scroll-parent > div > div {
 .notes-list {
     width: calc(100% - 20px);
 }
+
 .notes-list td, .notes-list th {
     text-align: left;
     color: var(--coolGrey);
 }
+
 .notes-list tr > th:first-child {
     padding-left: 2rem;
 }
+
 .notes-list tr > td:last-child,
 .notes-list tr > th:last-child {
     padding-right: 2rem;
@@ -413,11 +434,13 @@ html .fabric-editor-popup-scroll-parent > div > div {
 
 .note-item {
     display: flex;
+   
     align-items: center;
 }
 .note-icon {
     margin-right: 1rem;
 }
+
 .note-link {
     text-decoration: none;
     text-transform: none;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -83,7 +83,7 @@ html .akEditor > div:first-child {
 }
 
 html .akEditor > div:first-child > div:first-child {
-    margin: auto;
+    margin: 0 15%;
     overflow: visible; /* important for dropdowns */
 }
 
@@ -125,36 +125,6 @@ html .akEditor > div:first-child > div:first-child + div hr {
   html {
     --notes-share-button-label: none; /* do not display the label in sharing button */
   }
-}
-
-@media (max-width: 810px) {
-    html .akEditor > div:first-child > div:first-child > div:first-child > div:first-child {
-        width: 480px; /* condensed view */
-    }
-}
-
-@media (max-width: 740px) {
-    html .akEditor > div:first-child > div:first-child > div:first-child > div:first-child {
-        width: 390px; /* block style as icon */
-    }
-}
-
-@media (max-width: 660px) {
-    html .akEditor > div:first-child > div:first-child > div:first-child > div:first-child {
-        width: 380px; /* merge ol and ul as dropdown */
-    }
-}
-
-@media (max-width: 610px) {
-    html .akEditor > div:first-child > div:first-child > div:first-child > div:first-child {
-        width: 350px; /* left icons as dropdown */
-    }
-}
-
-@media (max-width: 530px) {
-    html .akEditor > div:first-child > div:first-child > div:first-child > div:first-child {
-        width: 280px; /* more left icons as dropdown */
-    }
 }
 
 @media (max-width: 375px) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5870,10 +5870,21 @@ cozy-device-helper@1.8.0:
   dependencies:
     lodash "4.17.15"
 
-cozy-doctypes@1.82.2, cozy-doctypes@^1.82.2:
+cozy-doctypes@1.82.2:
   version "1.82.2"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.82.2.tgz#7c7d6f44e3aaee18ba51253468e84d2d1a70fde6"
   integrity sha512-NWbQ6rKj2a+Rq19MX9uNa8GNlzwdlye9pxiC1V3jd+76T5fQMQN+tjHr9jK468V/NJvC/oQowAcWsRoMaB5A+Q==
+  dependencies:
+    cozy-logger "^1.7.0"
+    date-fns "^1.30.1"
+    es6-promise-pool "^2.5.0"
+    lodash "^4.17.19"
+    prop-types "^15.7.2"
+
+cozy-doctypes@^1.82.3:
+  version "1.82.3"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.82.3.tgz#e8e759c7698fb2718a35c06e46b24c000a2b3cd4"
+  integrity sha512-u2WRc2tD8SdR9MMFN49cAk7Wl5d11JgypBNzmrjXrziFUA5dTK3dTxJFA+tGlTfZSjJ+dfwuMYvZFf/iIg0Q4w==
   dependencies:
     cozy-logger "^1.7.0"
     date-fns "^1.30.1"
@@ -6100,19 +6111,20 @@ cozy-scripts@eslint7:
     webpack-dev-server "3.10.3"
     webpack-merge "4.2.2"
 
-cozy-sharing@3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-3.4.2.tgz#cfb07aa25fd36b70c01e919fc495b09119b6bea6"
-  integrity sha512-isTPwxdDMgu43CgSDLnMGPLVxYZAnfuZ+dhkAGojvbcWUlvWPfDoSmuInZJx5aH3B6rFAzzNFx8gC/V3z9LW5A==
+cozy-sharing@3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-3.7.0.tgz#1255c53ec94332b14a18793bbb025821fdadb497"
+  integrity sha512-3LlsZLjmIqnUQhoSYe1LVEtXLfIxblTA9FTtFeTUfO0fWtPzzy/57ana2LwdUSsvbsen/WFkLh0dBV4fZOoXbw==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.2.6"
     copy-text-to-clipboard "^2.1.1"
     cozy-device-helper "^1.12.0"
-    cozy-doctypes "^1.82.2"
+    cozy-doctypes "^1.82.3"
     lodash "^4.17.19"
     react-autosuggest "^9.4.3"
     react-tooltip "^3.11.1"
+    snarkdown "^2.0.0"
 
 cozy-stack-client@^13.8.3:
   version "13.20.2"
@@ -14304,6 +14316,11 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+snarkdown@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/snarkdown/-/snarkdown-2.0.0.tgz#b1feb4db91b9f94a8ebbd7a50f3e99aee18b1e03"
+  integrity sha512-MgL/7k/AZdXCTJiNgrO7chgDqaB9FGM/1Tvlcenenb7div6obaDATzs16JhFyHHBGodHT3B7RzRc5qk8pFhg3A==
 
 sockjs-client@1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Related to: https://trello.com/c/AiQg5Cjr/16-%F0%9F%93%9D-notes-partage-cozy-%C3%A0-cozy-notes-4j

Features:

- Add a new route to allow users to preview a note from email sharing
- Allows `Notes` to interact with `Contacts` (necessary for sharing to work as intended)
- Render the new `SharingBannerPlugin` in `Editor`; which manages itself
- Update the sharing modal in order to allow a user to share a note by email
- Update editor CSS overrides in order to display the `SharingBannerPlugin` in a `cozy-drive` way

Caveats:
- There are some questions about the post-sharing view. Should it go to the shared note or (currently) the shared note folder?
- Some old code about link sharing might be outdated by now. Should we review it entirely or continue to let it manage link sharing?

![image](https://user-images.githubusercontent.com/12577784/132169967-61c85fa7-e0ec-4f79-bf41-766c2130791a.png)
