### PR TITLE
Release/1.17.1

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,6 +3,11 @@
 ## ✨ Features
 
 * Add Cozy-to-Cozy sharing
+# 1.17.1
+
+## 🐛 Bug Fixes
+
+* Update ProseMirror schema to accept Date nodetype which was previously removed
 
 # 1.17.0
 

--- a/src/lib/collab/schema.js
+++ b/src/lib/collab/schema.js
@@ -30,13 +30,31 @@ import { Schema } from 'prosemirror-model'
 
 // if you edit the schema, please upgrade this schemaVersion
 
-export const schemaVersion = 2
+export const schemaVersion = 3
 
 export const getSchemaVersion = () => {
   return schemaVersion
 }
 
 export const nodes = [
+  [
+    'date',
+    {
+      inline: true,
+      group: 'inline',
+      selectable: true,
+      attrs: {
+        timestamp: {
+          default: ''
+        }
+      },
+      parseDOM: [
+        {
+          tag: 'span[data-node-type="date"]'
+        }
+      ]
+    }
+  ],
   [
     'status',
     {
@@ -51,7 +69,7 @@ export const nodes = [
           default: ''
         },
         localId: {
-          default: 'd25eecb0-0808-4ffe-a971-385acf81c093'
+          default: 'adf1f61a-da02-4a41-a6c3-183fdcac102d'
         },
         style: {
           default: ''
@@ -358,7 +376,7 @@ export const nodes = [
       group: 'block',
       selectable: true,
       atom: true,
-      content: 'media',
+      content: 'media | media ( unsupportedBlock)',
       attrs: {
         width: {
           default: null


### PR DESCRIPTION
This fixes a mistake in the Prosemirror schema. During image feature development we removed the Date node type from the schema. We added it back in this release because otherwise, it broke every note which used this node type.