### PR TITLE
fix: Update SharedRecipients styles to match drive

### DIFF
--- a/src/components/notes/List/NoteRow.jsx
+++ b/src/components/notes/List/NoteRow.jsx
@@ -100,7 +100,7 @@ const NoteRow = ({ note, f, t, client }) => {
               </AppLinker>
             </TableCell>
             <TableCell className={styles.tableCell}>
-              <SharedRecipients docId={note._id} size="small" />
+              <SharedRecipients docId={note._id} size={24} />
             </TableCell>
           </>
         )}

--- a/src/components/notes/List/list.styl
+++ b/src/components/notes/List/list.styl
@@ -39,3 +39,6 @@ $PADDING_TABLE_FIRST_COLUMN=2rem
 +small-screen()
     .tableRow:nth-of-type(1)
         border-top 0
+
+[class^="styles__c-avatar"]
+    border-color: var(--defaultBackgroundColor)


### PR DESCRIPTION
related to: https://trello.com/c/AiQg5Cjr/16-%F0%9F%93%9D-notes-partage-cozy-%C3%A0-cozy-notes-4j

We just use small CSS patches and change the size prop (value taken from Zeplin). Other solutions could be reworking the SharedRecipients component but at this point, I'm afraid of unintended side-effects in cozy-drive or elsewhere. Also, in terms of use, it makes sense that SharedRecipients does not necessarily know its border color in every scenario.