### PR TITLE
feat: Remove filename

### DIFF
--- a/src/components/notes/List/NotePath.tsx
+++ b/src/components/notes/List/NotePath.tsx
@@ -4,7 +4,7 @@ import FilePathLink from 'cozy-ui/transpiled/react/FilePathLink'
 import AppLinker from 'cozy-ui/transpiled/react/AppLinker'
 
 import { Slugs } from 'constants/strings'
-import { stopPropagation } from 'lib/helpers'
+import { removeFilename, stopPropagation } from 'lib/helpers'
 
 export const NotePath: React.FC<{
   drivePath: string
@@ -20,7 +20,7 @@ export const NotePath: React.FC<{
           ? { target: '_blank', rel: 'noreferrer noopener' }
           : { target })}
       >
-        {path}
+        {removeFilename(path)}
       </FilePathLink>
     )}
   </AppLinker>

--- a/src/lib/helpers.spec.ts
+++ b/src/lib/helpers.spec.ts
@@ -1,0 +1,43 @@
+import { removeFilename } from './helpers'
+
+describe('removeFilename', () => {
+  it('Works with 0 level', () => {
+    const filename = '/Foo'
+    const filepath = ''
+
+    expect(removeFilename(filepath + filename)).toBe(filename)
+  })
+
+  it('Works with 1 level', () => {
+    const filename = '/Foo'
+    const filepath = '/Bar'
+
+    expect(removeFilename(filepath + filename)).toBe(filepath)
+  })
+
+  it('Works with 2 level', () => {
+    const filename = '/Foo'
+    const filepath = '/Foo/Bar'
+
+    expect(removeFilename(filepath + filename)).toBe(filepath)
+  })
+
+  it('Works with input without slashes by returning input', () => {
+    const input = 'FooBarBaz'
+
+    expect(removeFilename(input)).toBe(input)
+  })
+
+  it('Works with unusual slashes in input', () => {
+    const filename = '/z'
+    const filepath = 'Fo/o/B//a/r/B///a'
+
+    expect(removeFilename(filepath + filename)).toBe(filepath)
+  })
+
+  it('Works with empty input', () => {
+    const input = ''
+
+    expect(removeFilename(input)).toBe(input)
+  })
+})

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -4,3 +4,6 @@ export const processFile = (
   file === null || typeof file === 'string' ? false : file
 
 export const stopPropagation = (event: Event): void => event.stopPropagation()
+
+export const removeFilename = (path: string): string =>
+  /(.+)(\/.+)$/.exec(path)?.[1] || path


### PR DESCRIPTION
Related to: https://trello.com/c/wozfDjxO/75-%F0%9F%93%9D-notes-ne-pas-afficher-le-nom-dans-le-chemin-de-la-note-mais-que-son-chemin

Simply display the path of a note without `/{noteName}`  by using a small RegExp.exec() call

![image](https://user-images.githubusercontent.com/12577784/134348150-e0f83354-7d48-401b-9d15-7f6bf6a27973.png)
