### PR TITLE
feat: Use updated title in sharing modal

### DIFF
--- a/src/components/notes/EditorCorner.jsx
+++ b/src/components/notes/EditorCorner.jsx
@@ -7,9 +7,9 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import SharingWidget from 'components/notes/sharing'
 
-const EditorCorner = ({ doc, isPublic, isReadOnly }) => {
+const EditorCorner = ({ doc, isPublic, isReadOnly, title }) => {
   const { t } = useI18n()
-  if (!isPublic) return <SharingWidget file={doc.file} />
+  if (!isPublic) return <SharingWidget file={doc.file} title={title} />
   else if (isReadOnly) {
     return (
       <Tooltip title={t('Notes.Editor.read_only')}>

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -113,7 +113,12 @@ export default function Editor(props) {
             />
           }
           rightComponent={
-            <EditorCorner doc={doc} isPublic={isPublic} isReadOnly={readOnly} />
+            <EditorCorner
+              doc={doc}
+              isPublic={isPublic}
+              isReadOnly={readOnly}
+              title={title}
+            />
           }
           primaryToolbarComponents={isPreview ? <SharingBannerPlugin /> : null}
         />

--- a/src/components/notes/sharing.jsx
+++ b/src/components/notes/sharing.jsx
@@ -14,10 +14,7 @@ export default function SharingWidget(props) {
 
   if (!file) return null
 
-  const {
-    id: noteId,
-    attributes: { name }
-  } = file
+  const { id: noteId } = file
 
   return (
     <>
@@ -30,10 +27,10 @@ export default function SharingWidget(props) {
       />
       {showModal && (
         <ShareModal
-          document={{ ...file, name }}
+          document={{ ...file, name: props.title }}
           documentType="Files"
           onClose={onClose}
-          sharingDesc={name}
+          sharingDesc={props.title}
         />
       )}
     </>


### PR DESCRIPTION
Use the updated title in real time in the sharing modal, not the title from the initial GET (which will never change until page refresh).