### PR TITLE
feat: Add drag and drop for images

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -21,8 +21,12 @@ const extraConfig = {
       ),
       [path.resolve(
         __dirname,
-        'node_modules/cozy-editor-core/src/plugins/media/index.tsx'
-      )]: path.resolve(__dirname, './src/plugins/media/index.tsx'),
+        'node_modules/cozy-editor-core/src/plugins/media'
+      )]: path.resolve(__dirname, './src/plugins/media'),
+      [path.resolve(
+        __dirname,
+        'node_modules/cozy-editor-core/src/plugins/image-upload'
+      )]: path.resolve(__dirname, './src/plugins/image-upload'),
       ['@atlaskit/editor-core']: path.resolve(
         __dirname,
         'node_modules/cozy-editor-core/src'

--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -92,11 +92,11 @@ function EditorView(props) {
           appearance="full-page"
           placeholder={t('Notes.EditorView.main_placeholder')}
           shouldFocus={!readOnly}
-          legacyImageUploadProvider={imageUploadProvider(
+          legacyImageUploadProvider={imageUploadProvider({
             collabProvider,
             t,
             setUploading
-          )}
+          })}
           primaryToolbarComponents={props.primaryToolbarComponents}
           contentComponents={
             <WithEditorActions

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -16,7 +16,8 @@ export enum InputType {
 
 export enum EventType {
   Click = 'click',
-  Change = 'change'
+  Change = 'change',
+  Drop = 'drop'
 }
 
 export enum RealTimeEvent {

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -17,7 +17,8 @@ export enum InputType {
 export enum EventType {
   Click = 'click',
   Change = 'change',
-  Drop = 'drop'
+  Drop = 'drop',
+  Paste = 'paste'
 }
 
 export enum RealTimeEvent {

--- a/src/lib/image-upload-provider.ts
+++ b/src/lib/image-upload-provider.ts
@@ -36,8 +36,14 @@ export const imageUploadProvider = (
   )
 
 const handleEvent = (event: Event | undefined, cb: FileCallback): void => {
-  if (event === undefined) return handleClick(cb)
-  if (event.type === EventType.Drop) return handleDrop(event as DragEvent, cb)
+  switch (event?.type) {
+    case EventType.Drop:
+      return handleDrop(event as DragEvent, cb)
+    case EventType.Paste:
+      return handlePaste(event as ClipboardEvent, cb)
+    default:
+      return handleClick(cb)
+  }
 }
 
 const handleClick = (cb: FileCallback): void => {
@@ -56,6 +62,9 @@ const handleClick = (cb: FileCallback): void => {
 
 const handleDrop = (event: DragEvent, cb: FileCallback): void =>
   cb(event.dataTransfer?.files?.[0])
+
+const handlePaste = (event: ClipboardEvent, cb: FileCallback): void =>
+  cb(event.clipboardData?.files?.[0])
 
 const uploadImage = (
   config: ImageUploadProviderConfig,

--- a/src/plugins/image-upload/event-handlers.ts
+++ b/src/plugins/image-upload/event-handlers.ts
@@ -1,0 +1,11 @@
+window.document.addEventListener(
+  'dragover',
+  event => (
+    event.preventDefault(),
+    !(<HTMLElement>event?.target).closest('.ProseMirror') &&
+      event.dataTransfer !== null &&
+      (event.dataTransfer.dropEffect = 'none')
+  )
+)
+
+export {}

--- a/src/plugins/image-upload/index.tsx
+++ b/src/plugins/image-upload/index.tsx
@@ -1,6 +1,7 @@
 import { EditorPlugin } from '@atlaskit/editor-core/types'
 import { createPlugin } from './pm-plugins/main'
 import inputRulePlugin from './pm-plugins/input-rule'
+import './event-handlers'
 
 const imageUpload = (): EditorPlugin => ({
   name: 'imageUpload',

--- a/src/plugins/image-upload/index.tsx
+++ b/src/plugins/image-upload/index.tsx
@@ -1,0 +1,22 @@
+import { EditorPlugin } from '@atlaskit/editor-core/types'
+import { createPlugin } from './pm-plugins/main'
+import inputRulePlugin from './pm-plugins/input-rule'
+
+const imageUpload = (): EditorPlugin => ({
+  name: 'imageUpload',
+
+  pmPlugins() {
+    return [
+      {
+        name: 'imageUpload',
+        plugin: createPlugin
+      },
+      {
+        name: 'imageUploadInputRule',
+        plugin: ({ schema }) => inputRulePlugin(schema)
+      }
+    ]
+  }
+})
+
+export default imageUpload

--- a/src/plugins/image-upload/pm-plugins/actions.ts
+++ b/src/plugins/image-upload/pm-plugins/actions.ts
@@ -1,0 +1,16 @@
+import { ImageUploadPluginAction } from '../types'
+import { Transaction } from 'prosemirror-state'
+import { stateKey } from './plugin-key'
+
+const imageUploadAction = (
+  tr: Transaction,
+  action: ImageUploadPluginAction
+): Transaction => {
+  return tr.setMeta(stateKey, action)
+}
+
+export const startUpload = (event: any) => (tr: Transaction) =>
+  imageUploadAction(tr, {
+    name: 'START_UPLOAD',
+    event
+  })

--- a/src/plugins/image-upload/pm-plugins/commands.ts
+++ b/src/plugins/image-upload/pm-plugins/commands.ts
@@ -1,0 +1,44 @@
+import { InsertedImageProperties } from '@atlaskit/editor-common/provider-factory'
+import { safeInsert } from 'prosemirror-utils'
+import { createExternalMediaNode } from '../utils'
+import { Command } from '@atlaskit/editor-core/types'
+import { ImageUploadPluginState } from '../types'
+import { startUpload } from './actions'
+import { stateKey } from './plugin-key'
+
+export const insertExternalImage: (
+  options: InsertedImageProperties
+) => Command = options => (state, dispatch) => {
+  console.log(state.selection.$to.pos)
+  const pluginState: ImageUploadPluginState = stateKey.getState(state)
+  if (!pluginState.enabled || !options.src) {
+    return false
+  }
+
+  const mediaNode = createExternalMediaNode(options.src, state.schema)
+  if (!mediaNode) {
+    return false
+  }
+
+  if (dispatch) {
+    dispatch(
+      safeInsert(mediaNode, state.selection.$to.pos)(state.tr).scrollIntoView()
+    )
+  }
+  return true
+}
+
+export const startImageUpload: (event?: Event) => Command = event => (
+  state,
+  dispatch
+) => {
+  const pluginState: ImageUploadPluginState = stateKey.getState(state)
+  if (!pluginState.enabled) {
+    return false
+  }
+
+  if (dispatch) {
+    dispatch(startUpload(event)(state.tr))
+  }
+  return true
+}

--- a/src/plugins/image-upload/pm-plugins/commands.ts
+++ b/src/plugins/image-upload/pm-plugins/commands.ts
@@ -9,7 +9,6 @@ import { stateKey } from './plugin-key'
 export const insertExternalImage: (
   options: InsertedImageProperties
 ) => Command = options => (state, dispatch) => {
-  console.log(state.selection.$to.pos)
   const pluginState: ImageUploadPluginState = stateKey.getState(state)
   if (!pluginState.enabled || !options.src) {
     return false

--- a/src/plugins/image-upload/pm-plugins/input-rule.ts
+++ b/src/plugins/image-upload/pm-plugins/input-rule.ts
@@ -1,0 +1,38 @@
+import { Schema } from 'prosemirror-model'
+import { Plugin } from 'prosemirror-state'
+import {
+  createInputRule,
+  instrumentedInputRule
+} from '@atlaskit/editor-core/utils/input-rules'
+import { createExternalMediaNode } from '../utils'
+
+export function inputRulePlugin(schema: Schema): Plugin | undefined {
+  if (!schema.nodes.media || !schema.nodes.mediaSingle) {
+    return
+  }
+
+  // ![something](link) should convert to an image
+  const imageRule = createInputRule(
+    /!\[(.*)\]\((\S+)\)$/,
+    (state, match, start, end) => {
+      const { schema } = state
+      const attrs = {
+        src: match[2],
+        alt: match[1]
+      }
+
+      const node = createExternalMediaNode(attrs.src, schema)
+      if (node) {
+        return state.tr.replaceWith(start, end, node)
+      }
+
+      return null
+    }
+  )
+
+  return instrumentedInputRule('image-upload', {
+    rules: [imageRule]
+  })
+}
+
+export default inputRulePlugin

--- a/src/plugins/image-upload/pm-plugins/main.ts
+++ b/src/plugins/image-upload/pm-plugins/main.ts
@@ -1,0 +1,138 @@
+import { EditorState, Plugin, Transaction } from 'prosemirror-state'
+
+import { isPastedFile } from '@atlaskit/editor-core/utils/clipboard'
+import { isDroppedFile } from '@atlaskit/editor-core/utils/drag-drop'
+
+import { canInsertMedia, isMediaSelected } from '../utils'
+import { ImageUploadPluginAction, ImageUploadPluginState } from '../types'
+import { EditorView } from 'prosemirror-view'
+import { insertExternalImage, startImageUpload } from './commands'
+import { PMPluginFactoryParams } from '@atlaskit/editor-core/types'
+import {
+  ImageUploadProvider,
+  Providers
+} from '@atlaskit/editor-common/provider-factory'
+import { stateKey } from './plugin-key'
+
+type DOMHandlerPredicate = (e: Event) => boolean
+const createDOMHandler = (pred: DOMHandlerPredicate, eventName: string) => (
+  view: EditorView,
+  event: Event
+) => {
+  if (!pred(event)) {
+    return false
+  }
+
+  event.preventDefault()
+  event.stopPropagation()
+
+  startImageUpload(event)(view.state, view.dispatch)
+
+  return true
+}
+
+const getNewActiveUpload = (
+  tr: Transaction,
+  pluginState: ImageUploadPluginState
+) => {
+  const meta: ImageUploadPluginAction | undefined = tr.getMeta(stateKey)
+  if (meta && meta.name === 'START_UPLOAD') {
+    return {
+      event: meta.event
+    }
+  }
+
+  return pluginState.activeUpload
+}
+
+export const createPlugin = ({
+  dispatch,
+  providerFactory
+}: PMPluginFactoryParams) => {
+  let uploadHandler: ImageUploadProvider | undefined
+
+  return new Plugin({
+    state: {
+      init(_config, state: EditorState): ImageUploadPluginState {
+        return {
+          active: false,
+          enabled: canInsertMedia(state),
+          hidden: !state.schema.nodes.media || !state.schema.nodes.mediaSingle
+        }
+      },
+      apply(tr, pluginState: ImageUploadPluginState, _oldState, newState) {
+        const newActive = isMediaSelected(newState)
+        const newEnabled = canInsertMedia(newState)
+        const newActiveUpload = getNewActiveUpload(tr, pluginState)
+
+        if (
+          newActive !== pluginState.active ||
+          newEnabled !== pluginState.enabled ||
+          newActiveUpload !== pluginState.activeUpload
+        ) {
+          const newPluginState = {
+            ...pluginState,
+            active: newActive,
+            enabled: newEnabled,
+            activeUpload: newActiveUpload
+          }
+
+          dispatch(stateKey, newPluginState)
+          return newPluginState
+        }
+
+        return pluginState
+      }
+    },
+    key: stateKey,
+    view: () => {
+      const handleProvider = async (
+        name: string,
+        provider?: Providers['imageUploadProvider']
+      ) => {
+        if (name !== 'imageUploadProvider' || !provider) {
+          return
+        }
+
+        try {
+          uploadHandler = await provider
+        } catch (e) {
+          uploadHandler = undefined
+        }
+      }
+
+      providerFactory.subscribe('imageUploadProvider', handleProvider)
+
+      return {
+        update(view, prevState) {
+          const { state: editorState } = view
+          const currentState: ImageUploadPluginState = stateKey.getState(
+            editorState
+          )!
+
+          // if we've add a new upload to the state, execute the uploadHandler
+          const oldState: ImageUploadPluginState = stateKey.getState(prevState)!
+          if (
+            currentState.activeUpload !== oldState.activeUpload &&
+            currentState.activeUpload &&
+            uploadHandler
+          ) {
+            uploadHandler(currentState.activeUpload.event, options =>
+              insertExternalImage(options)(view.state, view.dispatch)
+            )
+          }
+        },
+
+        destroy() {
+          providerFactory.unsubscribe('imageUploadProvider', handleProvider)
+        }
+      }
+    },
+    props: {
+      handleDOMEvents: {
+        drop: createDOMHandler(isDroppedFile, 'atlassian.editor.image.drop'),
+        paste: createDOMHandler(isPastedFile, 'atlassian.editor.image.paste')
+      }
+    }
+  })
+}

--- a/src/plugins/image-upload/pm-plugins/main.ts
+++ b/src/plugins/image-upload/pm-plugins/main.ts
@@ -3,7 +3,11 @@ import { EditorState, Plugin, Transaction } from 'prosemirror-state'
 import { isPastedFile } from '@atlaskit/editor-core/utils/clipboard'
 import { isDroppedFile } from '@atlaskit/editor-core/utils/drag-drop'
 
-import { canInsertMedia, isMediaSelected } from '../utils'
+import {
+  canInsertMedia,
+  isMediaSelected,
+  setSelectionAtDropPoint
+} from '../utils'
 import { ImageUploadPluginAction, ImageUploadPluginState } from '../types'
 import { EditorView } from 'prosemirror-view'
 import { insertExternalImage, startImageUpload } from './commands'
@@ -13,6 +17,7 @@ import {
   Providers
 } from '@atlaskit/editor-common/provider-factory'
 import { stateKey } from './plugin-key'
+import { EventType } from 'constants/strings'
 
 type DOMHandlerPredicate = (e: Event) => boolean
 const createDOMHandler = (pred: DOMHandlerPredicate, eventName: string) => (
@@ -25,6 +30,9 @@ const createDOMHandler = (pred: DOMHandlerPredicate, eventName: string) => (
 
   event.preventDefault()
   event.stopPropagation()
+
+  if (event.type === EventType.Drop)
+    setSelectionAtDropPoint(event as DragEvent, view)
 
   startImageUpload(event)(view.state, view.dispatch)
 

--- a/src/plugins/image-upload/pm-plugins/plugin-key.ts
+++ b/src/plugins/image-upload/pm-plugins/plugin-key.ts
@@ -1,0 +1,3 @@
+import { PluginKey } from 'prosemirror-state'
+
+export const stateKey = new PluginKey('imageUploadPlugin')

--- a/src/plugins/image-upload/types.ts
+++ b/src/plugins/image-upload/types.ts
@@ -1,0 +1,18 @@
+export type {
+  InsertedImageProperties,
+  ImageUploadProvider as ImageUploadHandler,
+} from '@atlaskit/editor-common/provider-factory'
+
+export type ImageUploadPluginAction = {
+  name: 'START_UPLOAD'
+  event?: Event
+}
+
+export type ImageUploadPluginState = {
+  active: boolean
+  enabled: boolean
+  hidden: boolean
+  activeUpload?: {
+    event?: Event
+  }
+}

--- a/src/plugins/image-upload/utils.ts
+++ b/src/plugins/image-upload/utils.ts
@@ -1,0 +1,42 @@
+import { EditorState, NodeSelection } from 'prosemirror-state'
+import { Schema, Node } from 'prosemirror-model'
+
+export const isMediaSelected = (state: EditorState): boolean => {
+  const { media } = state.schema.nodes
+
+  return (
+    state.selection instanceof NodeSelection &&
+    state.selection.node.type === media
+  )
+}
+
+export const canInsertMedia = (state: EditorState): boolean => {
+  const { mediaSingle } = state.schema.nodes
+  const { $to } = state.selection
+
+  if (mediaSingle) {
+    for (let d = $to.depth; d >= 0; d--) {
+      const index = $to.index(d)
+      if ($to.node(d).canReplaceWith(index, index, mediaSingle)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+export const createExternalMediaNode = (
+  url: string,
+  schema: Schema
+): Node | null => {
+  const { media, mediaSingle } = schema.nodes
+  if (!media || !mediaSingle) {
+    return null
+  }
+
+  const mediaNode = media.createChecked({
+    type: 'external',
+    url
+  })
+  return mediaSingle.createChecked({}, mediaNode)
+}

--- a/src/plugins/image-upload/utils.ts
+++ b/src/plugins/image-upload/utils.ts
@@ -1,5 +1,6 @@
-import { EditorState, NodeSelection } from 'prosemirror-state'
+import { EditorState, NodeSelection, TextSelection } from 'prosemirror-state'
 import { Schema, Node } from 'prosemirror-model'
+import { EditorView } from 'prosemirror-view'
 
 export const isMediaSelected = (state: EditorState): boolean => {
   const { media } = state.schema.nodes
@@ -40,3 +41,16 @@ export const createExternalMediaNode = (
   })
   return mediaSingle.createChecked({}, mediaNode)
 }
+
+export const setSelectionAtDropPoint = (
+  { clientX, clientY }: DragEvent,
+  view: EditorView
+): void =>
+  view.dispatch(
+    view.state.tr.setSelection(
+      TextSelection.create(
+        view.state.doc,
+        view.posAtCoords({ left: clientX, top: clientY })?.pos || 0
+      )
+    )
+  )

--- a/src/plugins/media/README.md
+++ b/src/plugins/media/README.md
@@ -1,0 +1,8 @@
+❔ The current fork of this plugin initially comes from [here](https://bitbucket.org/atlassian/atlassian-frontend-mirror/src/cd7cf8a57b0c4239085722d070f0086871b6fe05/editor/editor-core/) as **v134.0.1**.
+
+If you want to check the source code please use the following commands:
+* `git clone https://bitbucket.org/atlassian/atlassian-frontend-mirror.git` (if not done already)
+* `cd atlassian-frontend-mirror/plugins/media`
+* `git checkout cd7cf8a57b0c4239085722d070f0086871b6fe05`
+
+❗ Do not attempt to update it with the latest version of `media-plugin` from `editor-core` as it would render it inoperable in the current `cozy-notes` ecosystem.

--- a/src/plugins/media/index.tsx
+++ b/src/plugins/media/index.tsx
@@ -47,11 +47,11 @@ const mediaPlugin = (options?: MediaOptions): EditorPlugin => ({
   name: 'media',
 
   nodes() {
-    const {
-      allowMediaGroup = true,
-      allowMediaSingle = false,
-      UNSAFE_allowImageCaptions = cozyMediaOptions.UNSAFE_allowImageCaptions
-    } = options || {}
+      const {
+        allowMediaGroup = true,
+        allowMediaSingle = false,
+        UNSAFE_allowImageCaptions = false,
+      } = options || {};
 
     const mediaSingleNode = UNSAFE_allowImageCaptions
       ? mediaSingleWithCaption
@@ -244,16 +244,16 @@ const mediaPlugin = (options?: MediaOptions): EditorPlugin => ({
     floatingToolbar: (state, intl, providerFactory) =>
       floatingToolbar(state, intl, {
         providerFactory,
-        allowResizing: cozyMediaOptions.allowResizing,
-        allowResizingInTables: cozyMediaOptions.allowResizingInTables,
-        allowAnnotation: cozyMediaOptions.allowAnnotation,
-        allowLinking: cozyMediaOptions.allowLinking,
+        allowResizing: options && options.allowResizing,
+        allowResizingInTables: options && options.allowResizingInTables,
+        allowAnnotation: options && options.allowAnnotation,
+        allowLinking: options && options.allowLinking,
         allowAdvancedToolBarOptions:
-          cozyMediaOptions.allowAdvancedToolBarOptions,
-        allowAltTextOnImages: cozyMediaOptions.allowAltTextOnImages,
-        altTextValidator: options && options.altTextValidator
-      })
+          options && options.allowAdvancedToolBarOptions,
+        allowAltTextOnImages: options && options.allowAltTextOnImages,
+        altTextValidator: options && options.altTextValidator,
+      }),
   }
 })
 
-export default mediaPlugin
+export default (options: MediaOptions): EditorPlugin => mediaPlugin({...options, ...cozyMediaOptions})

--- a/src/plugins/media/nodeviews/mediaNodeView/index.tsx
+++ b/src/plugins/media/nodeviews/mediaNodeView/index.tsx
@@ -30,7 +30,6 @@ import { stateKey as mediaStateKey } from '../../pm-plugins/plugin-key'
 import { MediaOptions } from '../../types'
 import { MediaNodeViewProps } from '../types'
 import MediaNode from './media'
-import { cozyMediaOptions } from 'config/cozy-media-options'
 import CollabProvider from 'lib/collab/provider'
 
 class MediaNodeView extends SelectionBasedNodeView<MediaNodeViewProps> {
@@ -180,7 +179,7 @@ export const ReactMediaNode = (
     {
       eventDispatcher,
       providerFactory,
-      mediaOptions: { ...mediaOptions, ...cozyMediaOptions }
+      mediaOptions
     }
   ).init()
 }

--- a/src/plugins/media/nodeviews/mediaSingle.tsx
+++ b/src/plugins/media/nodeviews/mediaSingle.tsx
@@ -42,7 +42,6 @@ import {
   floatingLayouts,
   isRichMediaInsideOfBlockNode
 } from '@atlaskit/editor-core/utils/rich-media-utils'
-import { cozyMediaOptions } from 'config/cozy-media-options'
 import {
   firefoxElement,
   initFirefoxDrag,
@@ -433,7 +432,7 @@ class MediaSingleNodeView extends ReactNodeView<MediaSingleNodeViewProps> {
                     getPos={getPos}
                     mediaProvider={mediaProvider}
                     contextIdentifierProvider={contextIdentifierProvider}
-                    mediaOptions={{ ...mediaOptions, ...cozyMediaOptions }}
+                    mediaOptions={mediaOptions}
                     view={this.view}
                     fullWidthMode={fullWidthMode}
                     selected={this.isNodeSelected}


### PR DESCRIPTION
### The feature asked: allow users to drag and drop images from his filesystem to the note.

### Implementation issues

- Atlaskit editor does not handle by default this feature
- It was impossible to activate it, nowhere in the codebase is it mentioned
- ProseMirror does have a plugin handling it, but Atlaskit does not use it

### Implementation

- Externalize `image-upload` plugin from Atlaskit to Cozy
- Add a function in that plugin that will set the editor selection to the drop location
- Improve image uploader to handle drop events
- Disallow the user to drop images outside ProseMirror with a global listener