### PR TITLE
feat: Implement MVP header

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["cozy-app/react"],
-  "ignorePatterns": ["src/plugins/**/*.ts", "src/plugins/**/*.tsx"],
+  "ignorePatterns": ["src/plugins/**/*.ts", "src/plugins/**/*.tsx", "src/ui/**/*.ts", "src/ui/**/*.tsx"],
   "parser": "@babel/eslint-parser",
   "overrides": [
     {

--- a/app.config.js
+++ b/app.config.js
@@ -27,6 +27,14 @@ const extraConfig = {
         __dirname,
         'node_modules/cozy-editor-core/src/plugins/image-upload'
       )]: path.resolve(__dirname, './src/plugins/image-upload'),
+      [path.resolve(
+        __dirname,
+        'node_modules/cozy-editor-core/src/ui/Dropdown'
+      )]: path.resolve(__dirname, './src/ui/Dropdown'),
+      [path.resolve(
+        __dirname,
+        'node_modules/cozy-editor-core/src/ui/DropdownMenu'
+      )]: path.resolve(__dirname, './src/ui/DropdownMenu'),
       ['@atlaskit/editor-core']: path.resolve(
         __dirname,
         'node_modules/cozy-editor-core/src'

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -7,7 +7,7 @@ import useClientErrors from 'cozy-client/dist/hooks/useClientErrors'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import { Layout, Main, Content } from 'cozy-ui/transpiled/react/Layout'
-import { Sprite as IconSprite } from 'cozy-ui/transpiled/react/Icon'
+import IconSprite from 'cozy-ui/transpiled/react/Icon/Sprite'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import AppTitle from 'cozy-ui/transpiled/react/AppTitle'
 import useBreakpoints, {

--- a/src/components/header_menu.jsx
+++ b/src/components/header_menu.jsx
@@ -1,11 +1,81 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
-const HeaderMenu = props => (
-  <header className={'page-header-menu ' + (props.className || '')}>
-    <div className="page-header-menu--left">{props.left}</div>
-    {props.children}
-    <div className="page-header-menu--right">{props.right}</div>
-  </header>
-)
+import AppLinker from 'cozy-ui/transpiled/react/AppLinker'
+import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import Link from 'cozy-ui/transpiled/react/Link'
+import { SharedRecipients } from 'cozy-sharing'
+import { Typography } from '@material-ui/core'
+import { Slugs } from 'constants/strings'
+import { NotePath } from './notes/List/NotePath'
+import { CozyFile } from 'cozy-doctypes'
+import { getDriveLink } from 'lib/utils'
+
+import styles from './header_menu.styl'
+import { WithBreakpoints } from './notes/List/WithBreakpoints'
+import { Breakpoints } from 'types/enums'
+
+const HeaderMenu = ({
+  homeHref,
+  backFromEditing,
+  editorCorner,
+  isPublic,
+  file,
+  client
+}) => {
+  const drivePath = useMemo(
+    () => getDriveLink(client, file.attributes.dir_id),
+    [client, file.attributes.dir_id]
+  )
+
+  const { filename } = CozyFile.splitFilename(file.attributes)
+
+  return (
+    <header className={styles['header-menu']}>
+      <WithBreakpoints hideOn={Breakpoints.Mobile}>
+        <AppLinker slug={Slugs.Home} href={homeHref}>
+          {({ href }) => (
+            <Link {...(!isPublic && { href })} className={styles['home-link']}>
+              <AppIcon app={Slugs.Home} alt={Slugs.Home} />
+            </Link>
+          )}
+        </AppLinker>
+
+        <Divider orientation="vertical" className={styles['divider']} />
+      </WithBreakpoints>
+
+      {backFromEditing && <div className="u-mr-1">{backFromEditing}</div>}
+
+      <div className={styles['file-infos']}>
+        <WithBreakpoints hideOn={Breakpoints.Mobile}>
+          <AppIcon
+            app={file.attributes.cozyMetadata.createdByApp}
+            className={styles['app-icon']}
+          />
+        </WithBreakpoints>
+
+        <div>
+          <Typography>
+            <strong>{filename}</strong>
+          </Typography>
+
+          <WithBreakpoints hideOn={Breakpoints.Mobile}>
+            <NotePath
+              drivePath={drivePath}
+              path={file.attributes.path || drivePath}
+              target="_blank"
+            />
+          </WithBreakpoints>
+        </div>
+      </div>
+
+      <WithBreakpoints hideOn={Breakpoints.Mobile}>
+        <SharedRecipients docId={file.id} size={24} />
+      </WithBreakpoints>
+
+      {editorCorner}
+    </header>
+  )
+}
 
 export default HeaderMenu

--- a/src/components/header_menu.jsx
+++ b/src/components/header_menu.jsx
@@ -21,7 +21,8 @@ const HeaderMenu = ({
   editorCorner,
   isPublic,
   file,
-  client
+  client,
+  primaryToolBarComponents
 }) => {
   const drivePath = useMemo(
     () => getDriveLink(client, file.attributes.dir_id),
@@ -62,7 +63,7 @@ const HeaderMenu = ({
           <WithBreakpoints hideOn={Breakpoints.Mobile}>
             <NotePath
               drivePath={drivePath}
-              path={file.attributes.path || drivePath}
+              path={file.attributes.path || drivePath.split('#')[1]}
               target="_blank"
             />
           </WithBreakpoints>
@@ -70,10 +71,12 @@ const HeaderMenu = ({
       </div>
 
       <WithBreakpoints hideOn={Breakpoints.Mobile}>
-        <SharedRecipients docId={file.id} size={24} />
+        <SharedRecipients docId={file.id} size={32} />
       </WithBreakpoints>
 
       {editorCorner}
+
+      {primaryToolBarComponents}
     </header>
   )
 }

--- a/src/components/header_menu.jsx
+++ b/src/components/header_menu.jsx
@@ -1,19 +1,19 @@
 import React, { useMemo } from 'react'
 
+import { models } from 'cozy-client'
+import { SharedRecipients } from 'cozy-sharing'
 import AppLinker from 'cozy-ui/transpiled/react/AppLinker'
 import AppIcon from 'cozy-ui/transpiled/react/AppIcon'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import Link from 'cozy-ui/transpiled/react/Link'
-import { SharedRecipients } from 'cozy-sharing'
-import { Typography } from '@material-ui/core'
-import { Slugs } from 'constants/strings'
-import { NotePath } from './notes/List/NotePath'
-import { CozyFile } from 'cozy-doctypes'
-import { getDriveLink } from 'lib/utils'
+import Typography from 'cozy-ui/transpiled/react/Typography'
 
-import styles from './header_menu.styl'
-import { WithBreakpoints } from './notes/List/WithBreakpoints'
+import { Slugs } from 'constants/strings'
 import { Breakpoints } from 'types/enums'
+import { getDriveLink } from 'lib/utils'
+import { NotePath } from './notes/List/NotePath'
+import { WithBreakpoints } from './notes/List/WithBreakpoints'
+import styles from './header_menu.styl'
 
 const HeaderMenu = ({
   homeHref,
@@ -28,8 +28,9 @@ const HeaderMenu = ({
     () => getDriveLink(client, file.attributes.dir_id),
     [client, file.attributes.dir_id]
   )
+  const simplifiedDrivePath = drivePath.split('#')[1]
 
-  const { filename } = CozyFile.splitFilename(file.attributes)
+  const { filename } = models.file.splitFilename(file.attributes)
 
   return (
     <header className={styles['header-menu']}>
@@ -42,7 +43,7 @@ const HeaderMenu = ({
           )}
         </AppLinker>
 
-        <Divider orientation="vertical" className={styles['divider']} />
+        <Divider orientation="vertical" className="u-mh-1" />
       </WithBreakpoints>
 
       {backFromEditing && <div className="u-mr-1">{backFromEditing}</div>}
@@ -63,7 +64,7 @@ const HeaderMenu = ({
           <WithBreakpoints hideOn={Breakpoints.Mobile}>
             <NotePath
               drivePath={drivePath}
-              path={file.attributes.path || drivePath.split('#')[1]}
+              path={file.attributes.path || simplifiedDrivePath}
               target="_blank"
             />
           </WithBreakpoints>

--- a/src/components/header_menu.styl
+++ b/src/components/header_menu.styl
@@ -1,8 +1,11 @@
 .header-menu
     align-items center
+    box-shadow 0px 0px 0px 0.5px rgba(29, 33, 42, 0.12), 0px 2px 4px rgba(29, 33, 42, 0.0793047), 0px 4px 16px rgba(29, 33, 42, 0.06)
     display flex
     justify-content space-between
     padding 0.5rem 1rem
+    position relative
+    z-index 1
 
 .app-icon
 .home-link

--- a/src/components/header_menu.styl
+++ b/src/components/header_menu.styl
@@ -5,7 +5,7 @@
     justify-content space-between
     padding 0.5rem 1rem
     position relative
-    z-index 1
+    z-index var(--zIndex-low) // Needed for the drop-shadow to be above the editor area
 
 .app-icon
 .home-link
@@ -21,5 +21,3 @@
     display flex
     flex-grow 1
 
-.divider
-    margin 0 1rem !important

--- a/src/components/header_menu.styl
+++ b/src/components/header_menu.styl
@@ -1,0 +1,22 @@
+.header-menu
+    align-items center
+    display flex
+    justify-content space-between
+    padding 0.5rem 1rem
+
+.app-icon
+.home-link
+    display block
+    height 32px
+    width 32px
+
+.app-icon
+    margin-right 1rem
+
+.file-infos
+    align-items center
+    display flex
+    flex-grow 1
+
+.divider
+    margin 0 1rem !important

--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -10,7 +10,6 @@ import Overlay from 'cozy-ui/transpiled/react/Overlay'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import editorConfig from 'components/notes/editor_config'
-import HeaderMenu from 'components/header_menu'
 import styles from 'components/notes/editor-view.styl'
 import { imageUploadProvider } from 'lib/image-upload-provider'
 
@@ -28,11 +27,10 @@ function EditorView(props) {
     defaultTitle,
     title,
     collabProvider,
-    leftComponent,
-    rightComponent,
     onContentChange,
     readOnly,
-    bannerRef
+    bannerRef,
+    headerMenu
   } = props
   const { t } = useI18n()
 
@@ -77,11 +75,7 @@ function EditorView(props) {
         </Overlay>
       )}
       <style>#coz-bar {'{ display: none }'}</style>
-      <HeaderMenu
-        left={leftComponent}
-        className="note-header-menu--editing"
-        right={rightComponent}
-      />
+      {headerMenu}
       <section className="note-editor-container">
         <Editor
           {...editorConfig}

--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -91,7 +91,6 @@ function EditorView(props) {
             t,
             setUploading
           })}
-          primaryToolbarComponents={props.primaryToolbarComponents}
           contentComponents={
             <WithEditorActions
               render={() => (

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -23,6 +23,7 @@ import { useDebugValue } from 'lib/debug'
 
 import useConfirmExit from 'cozy-ui/transpiled/react/hooks/useConfirmExit'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import HeaderMenu from 'components/header_menu'
 
 export default function Editor(props) {
   // base parameters
@@ -105,19 +106,29 @@ export default function Editor(props) {
           defaultTitle={t('Notes.Editor.title_placeholder')}
           defaultValue={{ ...doc.doc, version: doc.version }}
           title={title && title.length > 0 ? title : undefined}
-          leftComponent={
-            <BackFromEditing
-              returnUrl={returnUrl}
-              file={doc.file}
-              requestToLeave={requestToLeave}
-            />
-          }
-          rightComponent={
-            <EditorCorner
-              doc={doc}
+          headerMenu={
+            <HeaderMenu
+              backFromEditing={
+                <BackFromEditing
+                  returnUrl={returnUrl}
+                  file={doc.file}
+                  requestToLeave={requestToLeave}
+                />
+              }
+              editorCorner={
+                <EditorCorner
+                  doc={doc}
+                  isPublic={isPublic}
+                  isReadOnly={readOnly}
+                  title={title}
+                />
+              }
+              homeHref={
+                collabProvider.serviceClient.cozyClient.getStackClient().uri
+              }
               isPublic={isPublic}
-              isReadOnly={readOnly}
-              title={title}
+              file={doc.file}
+              client={collabProvider.serviceClient.cozyClient}
             />
           }
           primaryToolbarComponents={isPreview ? <SharingBannerPlugin /> : null}

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -129,9 +129,11 @@ export default function Editor(props) {
               isPublic={isPublic}
               file={doc.file}
               client={collabProvider.serviceClient.cozyClient}
+              primaryToolbarComponents={
+                isPreview ? <SharingBannerPlugin /> : null
+              }
             />
           }
-          primaryToolbarComponents={isPreview ? <SharingBannerPlugin /> : null}
         />
         <SavingIndicator
           collabProvider={collabProvider}

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -33,7 +33,9 @@ export enum CozyDoctypes {
 }
 
 export enum Slugs {
-  Drive = 'drive'
+  Drive = 'drive',
+  Home = 'home',
+  Notes = 'notes'
 }
 
 export const SHARING_LOCATION = '/preview'

--- a/src/locales/atlassian_missing_french.json
+++ b/src/locales/atlassian_missing_french.json
@@ -9,5 +9,7 @@
     "fabric.editor.layoutFixedWidth": "Retour au centre",
     "fabric.editor.alignImageLeft": "Aligner l'image à gauche",
     "fabric.editor.alignImageCenter": "Centrer l'image",
-    "fabric.editor.alignImageRight": "Aligner l'image à droite"
+    "fabric.editor.alignImageRight": "Aligner l'image à droite",
+    "fabric.editor.numberedColumn": "Lignes numérotées"
+
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -77,10 +77,19 @@ html .akEditor > div:first-child {
 
 /* prose mirror toolbar in the upper bar */
 html .akEditor > div:first-child {
-    margin-bottom: 0;
+    width: 100%;
     flex-wrap: wrap;
     height: auto;
-    box-shadow: 0 11px 9px 0 rgba(0, 0, 0, 0.08), 0 3px 3px 0 rgba(50, 54, 63, 0.08);
+    position: fixed;
+    top: auto;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+html .akEditor > div:first-child > div > div:last-child {
+    box-shadow: 0px 0px 0px 0.5px rgba(29, 33, 42, 0.12), 0px 2px 4px rgba(29, 33, 42, 0.0793047), 0px 4px 16px rgba(29, 33, 42, 0.06);
+    border-radius: 8px;
 }
 
 /* This is the main toolbar wrapper */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -35,7 +35,7 @@ html {
     --note-title5-color: var(--coolGrey);
     --note-title6-color: var(--coolGrey);
     --note-border-radius: 8px;
-    --note-header-height: 3rem;
+    --note-header-height: 64px;
     --note-header-height-half: 1.5rem;
     color: var(--note-base-color);
 }
@@ -72,7 +72,7 @@ html .akEditor > div:first-child {
 }
 
 .note-editor-container {
-    height: calc(100% - 48px);
+    overflow: hidden;
 }
 
 /* prose mirror toolbar in the upper bar */
@@ -82,16 +82,19 @@ html .akEditor > div:first-child {
     height: auto;
     position: fixed;
     top: auto;
-    bottom: 1rem;
+    bottom: calc(env(safe-area-inset-bottom, 1rem) + 1rem);
     left: 50%;
     transform: translateX(-50%);
+    background: none;
+    box-shadow: none;
 }
 
 /* toolbar inner wrapper */
 html .akEditor > div:first-child > div > div:last-child {
     box-shadow: 0px 0px 0px 0.5px rgba(29, 33, 42, 0.12), 0px 2px 4px rgba(29, 33, 42, 0.0793047), 0px 4px 16px rgba(29, 33, 42, 0.06);
     border-radius: 8px;
-    padding: 0 0.5rem;
+    padding: 0.5rem;
+    background: white;
 }
 
 /* This is the main toolbar wrapper */
@@ -120,14 +123,12 @@ html .akEditor > div:first-child > div:first-child + div hr {
 [data-testid="ak-editor-main-toolbar"] > div > div:nth-child(2) {
     display: flex;
     align-items: center;
-    width: 730px; /* full toolbar */
-    max-width: 100%;
+    max-width: 768px;
     margin: auto;
-    height: var(--note-header-height);
 }
 
 [data-testid="ak-editor-main-toolbar"] + div {
-    height: calc(100% - 130px);
+    height: calc(100%);
 }
 
 /* 
@@ -402,7 +403,7 @@ html .fabric-editor-popup-scroll-parent > div > div {
 }
 
 html .ak-editor-content-area {
-    padding: var(--documentTopPadding) var(--documentPadding) var(--documentPadding) var(--documentPadding) !important;
+    padding: var(--documentTopPadding) var(--documentPadding) calc(3 * var(--note-base-size)) var(--documentPadding) !important;
     background-color: var(--white);
 }
 
@@ -453,4 +454,15 @@ html .fabric-editor-popup-scroll-parent > div > div {
 .richMedia-resize-handle-left,
 .richMedia-resize-handle-right {
     z-index: auto !important;
+}
+
+/* Required for toolbar's popups because unidentified internals miscalculate the popups position */
+/* Since we always display the toolbar at the bottom of the screen we do not care about any other top position than zero */
+[data-testid="ak-editor-main-toolbar"] [aria-label*="Popup"] {
+    top: 0 !important;
+}
+
+/* Weird overflow linked to the floating toolbar, could not locate the exact origin of the problem */
+body {
+    overflow-x: hidden;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -87,9 +87,11 @@ html .akEditor > div:first-child {
     transform: translateX(-50%);
 }
 
+/* toolbar inner wrapper */
 html .akEditor > div:first-child > div > div:last-child {
     box-shadow: 0px 0px 0px 0.5px rgba(29, 33, 42, 0.12), 0px 2px 4px rgba(29, 33, 42, 0.0793047), 0px 4px 16px rgba(29, 33, 42, 0.06);
     border-radius: 8px;
+    padding: 0 0.5rem;
 }
 
 /* This is the main toolbar wrapper */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -80,7 +80,7 @@ html .akEditor > div:first-child {
     margin-bottom: 0;
     flex-wrap: wrap;
     height: auto;
-    box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.08), 0 2px 4px 0 rgba(50, 54, 63, 0.08);
+    box-shadow: 0 11px 9px 0 rgba(0, 0, 0, 0.08), 0 3px 3px 0 rgba(50, 54, 63, 0.08);
 }
 
 /* This is the main toolbar wrapper */

--- a/src/ui/Dropdown/index.tsx
+++ b/src/ui/Dropdown/index.tsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import { PureComponent } from 'react'
+import DropdownList from '@atlaskit/droplist'
+import { Popup } from '@atlaskit/editor-common'
+import withOuterListeners from '../with-outer-listeners'
+
+export interface Props {
+  mountTo?: HTMLElement
+  boundariesElement?: HTMLElement
+  scrollableElement?: HTMLElement
+  trigger: React.ReactElement<any>
+  isOpen?: boolean
+  onOpenChange?: (attrs: any) => void
+  fitWidth?: number
+  fitHeight?: number
+  zIndex?: number
+}
+
+export interface State {
+  target?: HTMLElement
+  popupPlacement: [string, string]
+}
+
+/**
+ * Wrapper around @atlaskit/droplist which uses Popup and Portal to render
+ * droplist outside of "overflow: hidden" containers when needed.
+ *
+ * Also it controls popper's placement.
+ */
+export class Dropdown extends PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props)
+
+    this.state = {
+      popupPlacement: ['bottom', 'left']
+    }
+  }
+
+  private handleRef = (target: HTMLElement | null) => {
+    this.setState({ target: target || undefined })
+  }
+
+  private updatePopupPlacement = (placement: [string, string]) => {
+    this.setState({ popupPlacement: placement })
+  }
+
+  private renderDropdown() {
+    const { target } = this.state
+    const {
+      children,
+      mountTo,
+      boundariesElement,
+      scrollableElement,
+      onOpenChange,
+      fitHeight,
+      fitWidth,
+      zIndex
+    } = this.props
+
+    return (
+      <Popup
+        target={target}
+        mountTo={mountTo}
+        boundariesElement={boundariesElement}
+        scrollableElement={scrollableElement}
+        onPlacementChanged={this.updatePopupPlacement}
+        fitHeight={fitHeight}
+        fitWidth={fitWidth}
+        zIndex={zIndex}
+      >
+        <div style={{ height: 0, minWidth: fitWidth || 0 }}>
+          <DropdownList
+            disabled={true}
+            isOpen={true}
+            onOpenChange={onOpenChange}
+            appearance="tall"
+            position="top left"
+            shouldFlip={false}
+            shouldFitContainer={true}
+          >
+            {children}
+          </DropdownList>
+        </div>
+      </Popup>
+    )
+  }
+
+  render() {
+    const { trigger, isOpen } = this.props
+
+    return (
+      <>
+        <div ref={this.handleRef}>{trigger}</div>
+        {isOpen ? this.renderDropdown() : null}
+      </>
+    )
+  }
+}
+
+const DropdownWithOuterListeners = withOuterListeners(Dropdown)
+
+export default DropdownWithOuterListeners

--- a/src/ui/DropdownMenu/index.tsx
+++ b/src/ui/DropdownMenu/index.tsx
@@ -1,0 +1,162 @@
+import React, { PureComponent } from 'react'
+import styled from 'styled-components'
+import DropList from '@atlaskit/droplist'
+import Item, { ItemGroup } from '@atlaskit/item'
+import Tooltip from '@atlaskit/tooltip'
+import { Popup } from '@atlaskit/editor-common'
+import { akEditorFloatingPanelZIndex } from '@atlaskit/editor-shared-styles'
+import withOuterListeners from '../with-outer-listeners'
+import { Props, State } from './types'
+
+const Wrapper = styled.div`
+  /* tooltip in ToolbarButton is display:block */
+  & > div > div {
+    display: flex;
+  }
+`
+
+const DropListWithOutsideListeners: any = withOuterListeners(DropList)
+
+/**
+ * Hack for item to imitate old dropdown-menu selected styles
+ */
+const ItemWrapper: any = styled.div`
+  ${(props: any) =>
+    props.isSelected
+      ? '&& > span, && > span:hover { background: #6c798f; color: #fff; }'
+      : ''};
+`
+
+const ItemContentWrapper: any = styled.span`
+  ${(props: any) => (props.hasElemBefore ? 'margin-left: 8px;' : '')};
+`
+
+/**
+ * Wrapper around @atlaskit/droplist which uses Popup and Portal to render
+ * dropdown-menu outside of "overflow: hidden" containers when needed.
+ *
+ * Also it controls popper's placement.
+ */
+export default class DropdownMenuWrapper extends PureComponent<Props, State> {
+  state: State = {
+    popupPlacement: ['bottom', 'left']
+  }
+
+  private handleRef = (target: HTMLElement | null) => {
+    this.setState({ target: target || undefined })
+  }
+
+  private updatePopupPlacement = (placement: [string, string]) => {
+    this.setState({ popupPlacement: placement })
+  }
+
+  private handleClose = () => {
+    if (this.props.onOpenChange) {
+      this.props.onOpenChange({ isOpen: false })
+    }
+  }
+
+  private renderItem(item: typeof Item) {
+    const { onItemActivated, onMouseEnter, onMouseLeave } = this.props
+
+    // onClick and value.name are the action indicators in the handlers
+    // If neither are present, don't wrap in an Item.
+    if (!item.onClick && !item.value && !item.value.name) {
+      return <span key={String(item.content)}>{item.content}</span>
+    }
+
+    const dropListItem = (
+      <ItemWrapper key={item.key || item.content} isSelected={item.isActive}>
+        <Item
+          elemBefore={item.elemBefore}
+          elemAfter={item.elemAfter}
+          isDisabled={item.isDisabled}
+          onClick={() => onItemActivated && onItemActivated({ item })}
+          onMouseEnter={() => onMouseEnter && onMouseEnter({ item })}
+          onMouseLeave={() => onMouseLeave && onMouseLeave({ item })}
+          className={item.className}
+        >
+          <ItemContentWrapper hasElemBefore={!!item.elemBefore}>
+            {item.content}
+          </ItemContentWrapper>
+        </Item>
+      </ItemWrapper>
+    )
+
+    if (item.tooltipDescription) {
+      return (
+        <Tooltip
+          key={item.key || item.content}
+          content={item.tooltipDescription}
+          position={item.tooltipPosition}
+        >
+          {dropListItem}
+        </Tooltip>
+      )
+    }
+
+    return dropListItem
+  }
+
+  private renderDropdownMenu() {
+    const { target, popupPlacement } = this.state
+    const {
+      items,
+      mountTo,
+      boundariesElement,
+      scrollableElement,
+      offset,
+      fitHeight,
+      fitWidth,
+      isOpen,
+      zIndex
+    } = this.props
+    const isCellPopup = items[0].items.some(
+      ({ content }) => content === 'Cell background'
+    )
+    const position = isCellPopup ? popupPlacement.join(' ') : 'top left'
+
+    return (
+      <Popup
+        target={isOpen ? target : undefined}
+        mountTo={mountTo}
+        boundariesElement={boundariesElement}
+        scrollableElement={scrollableElement}
+        onPlacementChanged={this.updatePopupPlacement}
+        fitHeight={fitHeight}
+        fitWidth={fitWidth}
+        zIndex={zIndex || akEditorFloatingPanelZIndex}
+        offset={offset}
+      >
+        <DropListWithOutsideListeners
+          isOpen={true}
+          appearance="tall"
+          position={position}
+          shouldFlip={false}
+          shouldFitContainer={true}
+          isTriggerNotTabbable={true}
+          handleClickOutside={this.handleClose}
+          handleEscapeKeydown={this.handleClose}
+        >
+          <div style={{ height: 0, minWidth: fitWidth || 0 }} />
+          {items.map((group, index) => (
+            <ItemGroup key={index}>
+              {group.items.map(item => this.renderItem(item))}
+            </ItemGroup>
+          ))}
+        </DropListWithOutsideListeners>
+      </Popup>
+    )
+  }
+
+  render() {
+    const { children, isOpen } = this.props
+
+    return (
+      <Wrapper>
+        <div ref={this.handleRef}>{children}</div>
+        {isOpen ? this.renderDropdownMenu() : null}
+      </Wrapper>
+    )
+  }
+}

--- a/src/ui/DropdownMenu/types.ts
+++ b/src/ui/DropdownMenu/types.ts
@@ -1,0 +1,43 @@
+import React from 'react'
+import EditorActions from '../../actions'
+
+export interface Props {
+  mountTo?: HTMLElement
+  boundariesElement?: HTMLElement
+  scrollableElement?: HTMLElement
+  isOpen?: boolean
+  onOpenChange?: (attrs: any) => void
+  onItemActivated?: (attrs: any) => void
+  onMouseEnter?: (attrs: any) => void
+  onMouseLeave?: (attrs: any) => void
+  fitWidth?: number
+  fitHeight?: number
+  offset?: Array<number>
+  zIndex?: number
+  items: Array<{
+    items: MenuItem[]
+  }>
+}
+
+export interface MenuItem {
+  key?: string
+  content: string | React.ReactChild | React.ReactFragment
+  value: {
+    name: string
+  }
+  shortcut?: string
+  elemBefore?: React.ReactElement<any>
+  elemAfter?: React.ReactElement<any>
+  tooltipDescription?: string
+  tooltipPosition?: string
+  isActive?: boolean
+  isDisabled?: boolean
+  handleRef?: any
+  className?: string
+  onClick?: (editorActions: EditorActions) => void
+}
+
+export interface State {
+  target?: HTMLElement
+  popupPlacement: [string, string]
+}

--- a/src/ui/with-outer-listeners.tsx
+++ b/src/ui/with-outer-listeners.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { ComponentClass, StatelessComponent, PureComponent } from 'react'
+import ReactDOM from 'react-dom'
+
+type SimpleEventHandler<T> = (event: T) => void
+
+export interface WithOutsideClickProps {
+  handleClickOutside?: SimpleEventHandler<MouseEvent>
+  handleEscapeKeydown?: SimpleEventHandler<KeyboardEvent>
+  handleEnterKeydown?: SimpleEventHandler<KeyboardEvent>
+}
+
+export default function withOuterListeners<P>(
+  Component: ComponentClass<P> | StatelessComponent<P>
+): ComponentClass<P & WithOutsideClickProps> {
+  return class WithOutsideClick extends PureComponent<
+    P & WithOutsideClickProps,
+    {}
+  > {
+    componentDidMount() {
+      if (this.props.handleClickOutside) {
+        document.addEventListener('click', this.handleClick, false)
+      }
+
+      if (this.props.handleEscapeKeydown) {
+        document.addEventListener('keydown', this.handleKeydown, false)
+      }
+    }
+
+    componentWillUnmount() {
+      if (this.props.handleClickOutside) {
+        document.removeEventListener('click', this.handleClick, false)
+      }
+
+      if (this.props.handleEscapeKeydown) {
+        document.removeEventListener('keydown', this.handleKeydown, false)
+      }
+    }
+
+    handleClick = (evt: MouseEvent) => {
+      const domNode = ReactDOM.findDOMNode(this) // eslint-disable-line react/no-find-dom-node
+      if (
+        !domNode ||
+        (evt.target instanceof Node && !domNode.contains(evt.target))
+      ) {
+        if (this.props.handleClickOutside) {
+          this.props.handleClickOutside(evt)
+        }
+      }
+    }
+
+    handleKeydown = (evt: KeyboardEvent) => {
+      if (evt.code === 'Escape' && this.props.handleEscapeKeydown) {
+        this.props.handleEscapeKeydown(evt)
+      } else if (evt.code === 'Enter' && this.props.handleEnterKeydown) {
+        this.props.handleEnterKeydown(evt)
+      }
+    }
+
+    render() {
+      return <Component {...this.props} />
+    }
+  }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12577784/137504245-703f5093-4213-4d1b-84ac-77f30e3efc52.png)

J'avais travaillé depuis le début en essayant de convertir la toolbar de drive en toolbar agnostique dans cozy-ui, malheureusement plus j'avançais plus j'avais l'impression de créer de la dette technique et de créer un composant très complexe avec beaucoup trop de props pour qu'il soit compatible à la fois avec drive et notes.

Etant insatisfait avec cela j'ai décidé d'annuler le travail qui était fait sur cozy-ui depuis la toolbar cozy-drive et j'ai recommencé from scratch sur cozy-notes, en utilisant cependant uniquement des composants déjà existants. Je n'ai malheureusement pas eu le temps de terminer cette approche en raison du switch trop tardif. Cela-dit, étant donné que les composants utilisés existent déjà, le MVP est fonctionnel.

En terme de reste à faire, il y a une anomalie sur le path de la note qui n'est pas fetch au bon endroit, et il faut aussi vérifier que le bouton de retour répond bien à la spec. Il y a aussi des possibilités de refactor. Quoi qu'il en soit en restant sur cette base découplée de la toolbar cozy-drive je pense que ces 3 points peuvent être terminés en un jour.