### PR TITLE
fix: Properly display note path

### DIFF
--- a/src/components/HeaderNotePath.jsx
+++ b/src/components/HeaderNotePath.jsx
@@ -1,0 +1,29 @@
+import React, { useMemo } from 'react'
+
+import { getDriveLink } from 'lib/utils'
+import { Breakpoints } from 'types/enums'
+import { NotePath } from './notes/List/NotePath'
+import { WithBreakpoints } from './notes/List/WithBreakpoints'
+import { useClient } from 'cozy-client'
+import useFileWithPath from 'hooks/useFileWithPath'
+
+export const HeaderNotePath = ({ file }) => {
+  const client = useClient()
+  const fileWithPath = useFileWithPath({ cozyClient: client, file })
+  const drivePath = useMemo(() => getDriveLink(client, file.attributes.dirId), [
+    client,
+    file.attributes.dirId
+  ])
+
+  return (
+    <WithBreakpoints hideOn={Breakpoints.Mobile}>
+      {fileWithPath ? (
+        <NotePath
+          drivePath={drivePath}
+          path={fileWithPath.path}
+          target="_blank"
+        />
+      ) : null}
+    </WithBreakpoints>
+  )
+}

--- a/src/components/header_menu.jsx
+++ b/src/components/header_menu.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import { models } from 'cozy-client'
 import { SharedRecipients } from 'cozy-sharing'
@@ -10,11 +10,10 @@ import Typography from 'cozy-ui/transpiled/react/Typography'
 
 import { Slugs } from 'constants/strings'
 import { Breakpoints } from 'types/enums'
-import { getDriveLink } from 'lib/utils'
-import { NotePath } from './notes/List/NotePath'
 import { WithBreakpoints } from './notes/List/WithBreakpoints'
 import styles from './header_menu.styl'
 import { useFetchIcons } from 'hooks/useFetchIcons'
+import { HeaderNotePath } from './HeaderNotePath'
 
 const HeaderMenu = ({
   homeHref,
@@ -22,14 +21,8 @@ const HeaderMenu = ({
   editorCorner,
   isPublic,
   file,
-  client,
   primaryToolBarComponents
 }) => {
-  const drivePath = useMemo(
-    () => getDriveLink(client, file.attributes.dir_id),
-    [client, file.attributes.dir_id]
-  )
-  const simplifiedDrivePath = drivePath.split('#')[1]
   const { fetchHomeIcon, fetchNoteIcon } = useFetchIcons()
   const { filename } = models.file.splitFilename(file.attributes)
 
@@ -67,13 +60,7 @@ const HeaderMenu = ({
             <strong>{filename}</strong>
           </Typography>
 
-          <WithBreakpoints hideOn={Breakpoints.Mobile}>
-            <NotePath
-              drivePath={drivePath}
-              path={file.attributes.path || simplifiedDrivePath}
-              target="_blank"
-            />
-          </WithBreakpoints>
+          {!isPublic && <HeaderNotePath file={file} />}
         </div>
       </div>
 

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -128,7 +128,6 @@ export default function Editor(props) {
               }
               isPublic={isPublic}
               file={doc.file}
-              client={collabProvider.serviceClient.cozyClient}
               primaryToolbarComponents={
                 isPreview ? <SharingBannerPlugin /> : null
               }

--- a/src/hooks/useFileWithPath.js
+++ b/src/hooks/useFileWithPath.js
@@ -3,7 +3,6 @@ import { models } from 'cozy-client'
 
 function useFileWithPath({ cozyClient, file }) {
   const [fileWithPath, setFileWithPath] = useState(undefined)
-
   useEffect(() => {
     async function getParent(rawFile) {
       const file = models.file.normalize(rawFile)


### PR DESCRIPTION
Related to https://trello.com/c/wpOZ52TO/95-%F0%9F%93%9D-notes-ne-pas-afficher-le-chemin-complet-dune-note-partag%C3%A9e

Using useFileWithPath() hook to get huiman readable filepath name