### PR TITLE
fix: Allow tabbing out of the title

### DIFF
--- a/src/hooks/useTitleChanges.js
+++ b/src/hooks/useTitleChanges.js
@@ -6,6 +6,12 @@ function useTitleChanges({ noteId, title, setTitle, serviceClient }) {
   const onLocalTitleChange = useCallback(
     serviceClient
       ? e => {
+          // Let the user tab out of the title when using the 'Enter' key
+          if (e.nativeEvent?.inputType === 'insertLineBreak')
+            return window.dispatchEvent(
+              new KeyboardEvent('keydown', { key: 9 })
+            )
+
           // forbid line feed and non standard spaces in title
           const modifiedTitle = e.target.value.replace(/[\r\t\n\xa0]+/g, ' ')
           if (title != modifiedTitle) {


### PR DESCRIPTION
https://trello.com/c/cz5BooES/98-%F0%9F%93%9D-notes-pouvoir-sortir-du-titre-apr%C3%A8s-un-entr%C3%A9e