### PR TITLE
fix: Handle failure when opening a note

### DIFF
--- a/src/components/notes/List/NoteRow.jsx
+++ b/src/components/notes/List/NoteRow.jsx
@@ -56,8 +56,12 @@ const NoteRow = ({ note, f, t, client }) => {
   const menuTriggerRef = React.createRef()
 
   const goToNote = async () => {
-    const url = await generateReturnUrlToNotesIndex(client, note)
-    window.location.href = url
+    try {
+      const url = await generateReturnUrlToNotesIndex(client, note)
+      window.location.href = url
+    } catch (error) {
+      Alerter.error(t('Error.loading_error_title'))
+    }
   }
 
   const handleKeyDown = e => {


### PR DESCRIPTION
https://trello.com/c/v8HGwuLB/93-%F0%9F%93%9D-notes-ui-mettre-un-message-derreur-quand-on-clique-sur-une-note-corrompue-exemple-404