### PR TITLE
fix: Sharing cozy to cozy

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "cozy-flags": "2.7.2",
     "cozy-realtime": "3.13.0",
     "cozy-scripts": "eslint7",
-    "cozy-sharing": "3.12.10",
+    "cozy-sharing": "^4.0.5",
     "cozy-ui": "51.12.0",
     "eslint-config-cozy-app": "1.6.0",
     "lodash": "4.17.21",

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -38,4 +38,4 @@ export enum Slugs {
   Notes = 'notes'
 }
 
-export const SHARING_LOCATION = '/preview'
+export const SHARING_LOCATION = '/preview/'

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -47,7 +47,7 @@ export async function generateReturnUrlToNotesIndex(client, doc) {
 async function getFilesOwnPermissions(client) {
   const permissionsData = await client
     .collection('io.cozy.permissions')
-    .getOwnPermissions()
+    .fetchOwnPermissions()
   const permissionObject = get(permissionsData, 'data.attributes.permissions')
   if (!permissionObject) throw `can't get self permissions`
   const permissions = Object.values(permissionObject)

--- a/src/lib/utils.spec.js
+++ b/src/lib/utils.spec.js
@@ -49,7 +49,7 @@ function setupClient(verbs = [], ids = ['first', 'other']) {
     }),
     query: async data => data,
     collection: () => ({
-      getOwnPermissions: async () => ({
+      fetchOwnPermissions: async () => ({
         data: {
           id: '9385e37389cb9f71a230168f245df2f8',
           _id: '9385e37389cb9f71a230168f245df2f8',

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -68,7 +68,11 @@ const renderApp = function(appLocale, client, isPublic) {
             <MuiCozyTheme>
               <IsPublicContext.Provider value={isPublic}>
                 {!isPublic && (
-                  <SharingProvider doctype="io.cozy.files" documentType="Notes">
+                  <SharingProvider
+                    doctype="io.cozy.files"
+                    documentType="Notes"
+                    previewPath="/preview/"
+                  >
                     <App isPublic={isPublic} />
                   </SharingProvider>
                 )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5883,10 +5883,10 @@ cozy-device-helper@1.8.0:
   dependencies:
     lodash "4.17.15"
 
-cozy-device-helper@^1.15.0:
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.16.1.tgz#559b6c3f104541b53603590ccd6fc89296878f26"
-  integrity sha512-20IZGl7O1+J9qft+zMElL5nrSakAgqOx00IDsbbnJSFDLYtbA6wW6tIKOahYB+YLsDXEwiw6bzccqjiBXU0JAQ==
+cozy-device-helper@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.17.0.tgz#fbce9737ea83c67969b2b173163b37299a36283c"
+  integrity sha512-G61i75dPe/JwLUxN0foWG34lnm+0iybMu05AjoXv/UU2fRsTPfNnsHH4ZRi5JS6OPK4ccuj+ffRmabdywo23TA==
   dependencies:
     lodash "^4.17.19"
 
@@ -5901,10 +5901,10 @@ cozy-doctypes@1.82.2:
     lodash "^4.17.19"
     prop-types "^15.7.2"
 
-cozy-doctypes@^1.83.3:
-  version "1.83.3"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.83.3.tgz#d777c124f98e93c350cb1be39c1c095bb3ebd390"
-  integrity sha512-LvuEVRvAcsi141h5lDIeozGO9E5bQmwx2vTiQ5n7/du3gl33LAtwPy44dOZ2awE4Z2+CzZfqb9QvSontPN9ScA==
+cozy-doctypes@^1.83.5:
+  version "1.83.5"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.83.5.tgz#2608bbedfbf0d28efa0695423a2ea7c5137f5ef7"
+  integrity sha512-r4YEMoEuLTwl5iJ//rkxjpylkqAvZVIrUhdIHTtEdiFkJ7Oo4vpNQznzOAqP3Jdw8tfZkWE3rR3TE/wk1Elseg==
   dependencies:
     cozy-logger "^1.8.0"
     date-fns "^1.30.1"
@@ -6139,16 +6139,16 @@ cozy-scripts@eslint7:
     webpack-dev-server "3.10.3"
     webpack-merge "4.2.2"
 
-cozy-sharing@3.12.10:
-  version "3.12.10"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-3.12.10.tgz#f713998f47aa8e648fa320147a1f4cb309087ff4"
-  integrity sha512-tVwgudh4aM9sFhMC55HnkWbSpwtEqP1XBFPlnZ19uOfiheLfW0qrKfF+B18ypMikRKo0oUjZPNDOh+qE0wuqqQ==
+cozy-sharing@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-4.0.5.tgz#c65d3719f548fcfc34891bffc38213e7894eb75b"
+  integrity sha512-UzedSKS+LhPrzYES7OXH7do9BgOL5YOP9le/ApUnR9OmTaVw/JZhsWA8tODa+yrAtls0gr3m6QNBKHRF9oflYA==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.2.6"
     copy-text-to-clipboard "^2.1.1"
-    cozy-device-helper "^1.15.0"
-    cozy-doctypes "^1.83.3"
+    cozy-device-helper "^1.17.0"
+    cozy-doctypes "^1.83.5"
     lodash "^4.17.19"
     react-autosuggest "^9.4.3"
     react-tooltip "^3.11.1"


### PR DESCRIPTION
When sharing cozy to cozy a note, we create a link to see
a preview.
Loading this preview from /preview?sharecode doesn't work
we need to load it from /preview/?sharecode.
