### PR TITLE
chore: Upgrade

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,11 @@
+# 1.19.0
+## 🐛 Bug Fixes
+
+* Fix preview for cozy to cozy sharing
+
+## 🔧 Tech
+
+* Upgrade cozy-sharing lib
 # 1.18.0
 
 ## ✨ Features

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -4,7 +4,7 @@
   "slug": "notes",
   "icon": "icon.svg",
   "categories": ["cozy"],
-  "version": "1.18.0",
+  "version": "1.19.0",
   "licence": "AGPL-3.0",
   "editor": "Cozy",
   "source": "https://github.com/cozy/cozy-notes.git@build",


### PR DESCRIPTION
We forgot to upgrade the version in the manifest.webapp after releasing the 1.18.0. Upgrading packge.json is not enough, we have to upgrade both files. 