### PR TITLE
fix: Sharing note with empty title

### DIFF
--- a/src/components/notes/sharing.jsx
+++ b/src/components/notes/sharing.jsx
@@ -27,7 +27,13 @@ export default function SharingWidget(props) {
       />
       {showModal && (
         <ShareModal
-          document={{ ...file, name: props.title }}
+          // If the user didn't write any title, then the props.title is undefined
+          // In that case, we fallback to the file.attributes.names. It'll be something
+          // like "New Note ...."
+          document={{
+            ...file,
+            name: props.title ? props.title : file.attributes.name
+          }}
           documentType="Files"
           onClose={onClose}
           sharingDesc={props.title}


### PR DESCRIPTION
If the user didn't write any title,
then the props.title is undefined
In that case, we fallback to the
file.attributes.names. It'll be something
like "New Note ...."

Cozy-Stack doesn't allow us to create
a sharing's rule with an empty string
as title.
