### PR TITLE
chore: Upgrade ubuntu to focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: node_js
 matrix:
   fast_finish: true


### PR DESCRIPTION
xenial is still the default ubuntu version
on Travis, but do not have standart support
anymore.

So let's use the latest available LTS at this
time.

See https://wiki.ubuntu.com/Releases for
more informations about ubuntu support.