### PR TITLE
feat: Upgrade react-router-dom to v6.3.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,5 +3,8 @@
   "ignorePatterns": ["src/plugins/**/*.ts", "src/plugins/**/*.tsx", "src/ui/**/*.ts", "src/ui/**/*.tsx"],
   "parserOptions": {
     "project": "tsconfig.json"
+  },
+  "globals": {
+    "cozy": "readonly"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-intl": "2.9.0",
-    "react-router-dom": "5.3.0",
+    "react-router-dom": "6.3.0",
     "rxjs": "5.5.12",
     "styled-components": "3.4.10",
     "url-search-params-polyfill": "7.0.1",

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -1,5 +1,4 @@
-/* global cozy */
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import {
   HashRouter,
   Route,
@@ -24,12 +23,12 @@ import { useClient } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 const manifest = require('../../manifest.webapp')
+import { AppRoutes } from 'constants/routes'
 import { List, Editor, Unshared } from 'components/notes'
+import { fetchIfIsNoteReadOnly } from 'lib/utils'
+import { getDataOrDefault } from 'lib/initFromDom'
 import { getReturnUrl, getSharedDocument } from 'lib/utils'
 import { useFlagSwitcher } from 'lib/debug'
-import { getDataOrDefault } from 'lib/initFromDom'
-import { fetchIfIsNoteReadOnly } from 'lib/utils'
-import { AppRoutes } from 'constants/routes'
 
 const RoutedEditor = () => {
   const { id } = useParams()
@@ -51,11 +50,16 @@ const PrivateContext = () => {
         <Route path={AppRoutes.Editor} element={<RoutedEditor />} />
       </Routes>
 
-      {state?.backgroundLocation && (
+      {state?.backgroundLocation && state?.shareModalProps && (
         <Routes>
           <Route
             path={AppRoutes.ShareFromList}
-            element={<ShareModal onClose={() => navigate(-1)} />}
+            element={
+              <ShareModal
+                onClose={() => navigate(-1)}
+                {...state.shareModalProps}
+              />
+            }
           />
         </Routes>
       )}

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -1,12 +1,12 @@
 /* global cozy */
 import React, { useState, useEffect, useMemo } from 'react'
 import {
-  useNavigate,
+  HashRouter,
   Route,
   Routes,
   useLocation,
-  useParams,
-  BrowserRouter
+  useNavigate,
+  useParams
 } from 'react-router-dom'
 
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
@@ -127,7 +127,7 @@ const App = ({ isPublic }) => {
 
   return (
     <>
-      <BrowserRouter>
+      <HashRouter>
         <Layout monoColumn={true}>
           {!isPublic && isMobile && (
             <BarCenter>
@@ -149,7 +149,7 @@ const App = ({ isPublic }) => {
 
           <FlagSwitcher />
         </Layout>
-      </BrowserRouter>
+      </HashRouter>
       <ClientErrors />
     </>
   )

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -1,12 +1,12 @@
 /* global cozy */
 import React, { useState, useEffect, useMemo } from 'react'
 import {
+  useNavigate,
   Route,
-  Switch,
-  HashRouter,
+  Routes,
   useLocation,
   useParams,
-  useRouteMatch
+  BrowserRouter
 } from 'react-router-dom'
 
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
@@ -29,7 +29,7 @@ import { getReturnUrl, getSharedDocument } from 'lib/utils'
 import { useFlagSwitcher } from 'lib/debug'
 import { getDataOrDefault } from 'lib/initFromDom'
 import { fetchIfIsNoteReadOnly } from 'lib/utils'
-import { Routes } from 'constants/routes'
+import { AppRoutes } from 'constants/routes'
 
 const RoutedEditor = () => {
   const { id } = useParams()
@@ -40,22 +40,25 @@ const RoutedEditor = () => {
 
 const PrivateContext = () => {
   const location = useLocation()
-  const background = location.state?.background
-  const matchShare = useRouteMatch(`/${Routes.ShareFromList}`)
+  const navigate = useNavigate()
+  const state = location.state
 
   return (
     <>
-      <Switch>
-        <Route path="/n/:id">
-          <RoutedEditor />
-        </Route>
+      <Routes location={state?.backgroundLocation || location}>
+        <Route path={AppRoutes.Root} element={<List />} />
 
-        <Route path="/">
-          <List />
-        </Route>
-      </Switch>
+        <Route path={AppRoutes.Editor} element={<RoutedEditor />} />
+      </Routes>
 
-      {background && matchShare && <ShareModal />}
+      {state?.backgroundLocation && (
+        <Routes>
+          <Route
+            path={AppRoutes.ShareFromList}
+            element={<ShareModal onClose={() => navigate(-1)} />}
+          />
+        </Routes>
+      )}
     </>
   )
 }
@@ -124,7 +127,7 @@ const App = ({ isPublic }) => {
 
   return (
     <>
-      <HashRouter>
+      <BrowserRouter>
         <Layout monoColumn={true}>
           {!isPublic && isMobile && (
             <BarCenter>
@@ -146,7 +149,7 @@ const App = ({ isPublic }) => {
 
           <FlagSwitcher />
         </Layout>
-      </HashRouter>
+      </BrowserRouter>
       <ClientErrors />
     </>
   )

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -4,8 +4,9 @@ import {
   Route,
   Switch,
   HashRouter,
-  withRouter,
-  useLocation
+  useLocation,
+  useParams,
+  useRouteMatch
 } from 'react-router-dom'
 
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
@@ -30,32 +31,31 @@ import { getDataOrDefault } from 'lib/initFromDom'
 import { fetchIfIsNoteReadOnly } from 'lib/utils'
 import { Routes } from 'constants/routes'
 
-const RoutedEditor = withRouter(props => {
+const RoutedEditor = () => {
+  const { id } = useParams()
   const returnUrl = getReturnUrl()
 
-  return (
-    <Editor
-      noteId={props.match.params.id}
-      returnUrl={returnUrl}
-      readOnly={false}
-    />
-  )
-})
+  return <Editor noteId={id} returnUrl={returnUrl} readOnly={false} />
+}
 
 const PrivateContext = () => {
   const location = useLocation()
   const background = location.state?.background
+  const matchShare = useRouteMatch(`/${Routes.ShareFromList}`)
 
   return (
     <>
       <Switch>
-        <Route path="/n/:id" component={RoutedEditor} />
-        <Route path="/" component={List} />
+        <Route path="/n/:id">
+          <RoutedEditor />
+        </Route>
+
+        <Route path="/">
+          <List />
+        </Route>
       </Switch>
 
-      {background && (
-        <Route path={`/${Routes.ShareFromList}`} component={ShareModal} />
-      )}
+      {background && matchShare && <ShareModal />}
     </>
   )
 }

--- a/src/components/notes/List/NoteRow.jsx
+++ b/src/components/notes/List/NoteRow.jsx
@@ -14,12 +14,12 @@ import { withClient } from 'cozy-client'
 
 import NoteIcon from 'assets/icons/icon-note-32.svg'
 import styles from 'components/notes/List/list.styl'
+import { AppRoutes } from 'constants/routes'
 import { Breakpoints } from 'types/enums'
+import { DocumentTypes } from 'constants/strings'
 import { NotePath } from './NotePath'
 import { WithBreakpoints } from './WithBreakpoints'
 import { generateReturnUrlToNotesIndex, getDriveLink } from 'lib/utils'
-import { AppRoutes } from 'constants/routes'
-import { DocumentTypes } from 'constants/strings'
 
 const NoteRow = ({ note, f, t, client }) => {
   const location = useLocation()
@@ -139,9 +139,9 @@ const NoteRow = ({ note, f, t, client }) => {
             to={AppRoutes.ShareFromList}
             state={{
               backgroundLocation: location,
-              modalProps: {
+              shareModalProps: {
                 document: { ...note, name: note.attributes.name },
-                documentType: DocumentTypes.Files,
+                documentType: DocumentTypes.Notes,
                 sharingDesc: note.attributes.name
               }
             }}
@@ -158,6 +158,7 @@ const NoteRow = ({ note, f, t, client }) => {
               {t('Notes.Files.share.cta')}
             </ActionMenuItem>
           </Link>
+
           <ActionMenuItem onClick={deleteNote} left={<Icon icon="trash" />}>
             {t('Notes.Delete.delete_note')}
           </ActionMenuItem>

--- a/src/components/notes/List/NoteRow.jsx
+++ b/src/components/notes/List/NoteRow.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react'
-import { Link, useLocation, useHistory } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 
 import ActionMenu, { ActionMenuItem } from 'cozy-ui/transpiled/react/ActionMenu'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
@@ -18,12 +18,11 @@ import { Breakpoints } from 'types/enums'
 import { NotePath } from './NotePath'
 import { WithBreakpoints } from './WithBreakpoints'
 import { generateReturnUrlToNotesIndex, getDriveLink } from 'lib/utils'
-import { Routes } from 'constants/routes'
+import { AppRoutes } from 'constants/routes'
 import { DocumentTypes } from 'constants/strings'
 
 const NoteRow = ({ note, f, t, client }) => {
   const location = useLocation()
-  const history = useHistory()
   const { filename, extension } = CozyFile.splitFilename(note)
   const [isMenuOpen, setMenuOpen] = useState(false)
 
@@ -137,16 +136,13 @@ const NoteRow = ({ note, f, t, client }) => {
           <Link
             className={styles.actionMenuItem}
             onClick={closeMenu}
-            to={{
-              pathname: `/${Routes.ShareFromList}`,
-              state: {
-                background: location,
-                modalProps: {
-                  document: { ...note, name: note.attributes.name },
-                  documentType: DocumentTypes.Notes,
-                  onClose: history.goBack,
-                  sharingDesc: note.attributes.name
-                }
+            to={AppRoutes.ShareFromList}
+            state={{
+              backgroundLocation: location,
+              modalProps: {
+                document: { ...note, name: note.attributes.name },
+                documentType: DocumentTypes.Files,
+                sharingDesc: note.attributes.name
               }
             }}
           >
@@ -162,7 +158,6 @@ const NoteRow = ({ note, f, t, client }) => {
               {t('Notes.Files.share.cta')}
             </ActionMenuItem>
           </Link>
-
           <ActionMenuItem onClick={deleteNote} left={<Icon icon="trash" />}>
             {t('Notes.Delete.delete_note')}
           </ActionMenuItem>

--- a/src/components/notes/List/index.jsx
+++ b/src/components/notes/List/index.jsx
@@ -1,5 +1,6 @@
 /* global cozy */
 import React from 'react'
+import { Outlet } from 'react-router-dom'
 
 import Stack from 'cozy-ui/transpiled/react/Stack'
 import { BarContextProvider, useI18n } from 'cozy-ui/transpiled/react/'
@@ -55,6 +56,8 @@ const ListView = () => {
               </BarRight>
             </WithBreakpoints>
           )}
+
+          <Outlet />
         </>
       )}
     </Query>

--- a/src/components/notes/List/index.jsx
+++ b/src/components/notes/List/index.jsx
@@ -1,17 +1,15 @@
-/* global cozy */
 import React from 'react'
-import { Outlet } from 'react-router-dom'
 
 import Stack from 'cozy-ui/transpiled/react/Stack'
 import { BarContextProvider, useI18n } from 'cozy-ui/transpiled/react/'
 import { Query, Q, useClient } from 'cozy-client'
 
+import Add, { AddMobile } from 'components/notes/add'
 import AppTitle from 'components/notes/List/AppTitle'
 import List from 'components/notes/List/List'
-import Add, { AddMobile } from 'components/notes/add'
 import styles from 'components/notes/List/list.styl'
-import { WithBreakpoints } from './WithBreakpoints'
 import { Breakpoints } from 'types/enums'
+import { WithBreakpoints } from './WithBreakpoints'
 
 const shouldDisplayAddButton = (fetchStatus, notes) =>
   fetchStatus === 'loaded' && notes.length > 0
@@ -56,8 +54,6 @@ const ListView = () => {
               </BarRight>
             </WithBreakpoints>
           )}
-
-          <Outlet />
         </>
       )}
     </Query>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,3 +1,5 @@
-export enum Routes {
+export enum AppRoutes {
+  Editor = 'n/:id',
+  Root = '/',
   ShareFromList = 'share'
 }

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -1,4 +1,3 @@
-/* global cozy */
 import 'cozy-ui/dist/cozy-ui.utils.min.css'
 import 'cozy-ui/transpiled/react/stylesheet.css'
 import 'cozy-sharing/dist/stylesheet.css'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3153,6 +3153,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.7.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.6.tgz#6a1ef59f838debd670421f8c7f2cbb8da9751580"
+  integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.14.5", "@babel/template@^7.2.2", "@babel/template@^7.3.3", "@babel/template@^7.8.6":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
@@ -9914,17 +9921,12 @@ highlight.js@^9.6.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
   integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
 
-history@^4.9.0:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
-  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+history@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
   dependencies:
-    "@babel/runtime" "^7.1.2"
-    loose-envify "^1.2.0"
-    resolve-pathname "^3.0.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
-    value-equal "^1.0.1"
+    "@babel/runtime" "^7.7.6"
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -10893,11 +10895,6 @@ is-wsl@^2.1.1, is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
-
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -12043,7 +12040,7 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -12434,14 +12431,6 @@ min-document@^2.19.0:
   integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
   dependencies:
     dom-walk "^0.1.0"
-
-mini-create-react-context@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
-  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
-  dependencies:
-    "@babel/runtime" "^7.12.1"
-    tiny-warning "^1.0.3"
 
 mini-css-extract-plugin@0.5.0:
   version "0.5.0"
@@ -13491,13 +13480,6 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
-
-path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
-  dependencies:
-    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -14663,34 +14645,20 @@ react-render-image@^1.1.3:
   resolved "https://registry.yarnpkg.com/react-render-image/-/react-render-image-1.1.3.tgz#65a35c7f18a5b5a7c24d717e82b2285186f02b9e"
   integrity sha512-FsrcqSed/P6AaWZq2ABgzfXOexbMFKc/i9W7Pk/jIFwiEdmM9/xzivVNMK4MdIRw5Q1sbaGTVfDozgMPxu/s7A==
 
-react-router-dom@5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.0.tgz#da1bfb535a0e89a712a93b97dd76f47ad1f32363"
-  integrity sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==
+react-router-dom@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
+  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
   dependencies:
-    "@babel/runtime" "^7.12.13"
-    history "^4.9.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.6.2"
-    react-router "5.2.1"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
+    history "^5.2.0"
+    react-router "6.3.0"
 
-react-router@5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.1.tgz#4d2e4e9d5ae9425091845b8dbc6d9d276239774d"
-  integrity sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==
+react-router@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
   dependencies:
-    "@babel/runtime" "^7.12.13"
-    history "^4.9.0"
-    hoist-non-react-statics "^3.1.0"
-    loose-envify "^1.3.1"
-    mini-create-react-context "^0.4.0"
-    path-to-regexp "^1.7.0"
-    prop-types "^15.6.2"
-    react-is "^16.6.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
+    history "^5.2.0"
 
 react-scrolllock@^5.0.1:
   version "5.0.1"
@@ -15253,11 +15221,6 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
-
-resolve-pathname@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
-  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -16631,12 +16594,12 @@ tiny-invariant@^0.0.3:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-0.0.3.tgz#4c7283c950e290889e9e94f64d3586ec9156cf44"
   integrity sha512-SA2YwvDrCITM9fTvHTHRpq9W6L2fBsClbqm3maT5PZux4Z73SPPDYwJMtnoWh6WMgmCkJij/LaOlWiqJqFMK8g==
 
-tiny-invariant@^1.0.2, tiny-invariant@^1.0.6:
+tiny-invariant@^1.0.6:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
   integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
 
-tiny-warning@^1.0.0, tiny-warning@^1.0.2, tiny-warning@^1.0.3:
+tiny-warning@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
@@ -17251,11 +17214,6 @@ validate-npm-package-name@3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
-
-value-equal@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
-  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
* Use <Route children> instead of <Route render> and/or <Route component> props

* Use our hooks API to access router state like the current location and params

* Replace all uses of withRouter with hooks

* Replace any <Route>s that are not inside a <Switch> with useRouteMatch, or wrap them in a <Switch>