### PR TITLE
fix: Apply correct documentType on shareModals

### DIFF
--- a/src/components/notes/List/NoteRow.jsx
+++ b/src/components/notes/List/NoteRow.jsx
@@ -143,7 +143,7 @@ const NoteRow = ({ note, f, t, client }) => {
                 background: location,
                 modalProps: {
                   document: { ...note, name: note.attributes.name },
-                  documentType: DocumentTypes.Files,
+                  documentType: DocumentTypes.Notes,
                   onClose: history.goBack,
                   sharingDesc: note.attributes.name
                 }

--- a/src/components/notes/sharing.jsx
+++ b/src/components/notes/sharing.jsx
@@ -4,6 +4,7 @@ import { useClient } from 'cozy-client'
 
 import useFileWithPath from 'hooks/useFileWithPath'
 import styles from 'components/notes/sharing.styl'
+import { DocumentTypes } from 'constants/strings'
 
 export default function SharingWidget(props) {
   const client = useClient()
@@ -34,7 +35,7 @@ export default function SharingWidget(props) {
             ...file,
             name: props.title ? props.title : file.attributes.name
           }}
-          documentType="Files"
+          documentType={DocumentTypes.Notes}
           onClose={onClose}
           sharingDesc={props.title}
         />

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -41,5 +41,6 @@ export enum Slugs {
 export const SHARING_LOCATION = '/preview/'
 
 export enum DocumentTypes {
-  Files = 'Files'
+  Files = 'Files',
+  Notes = 'Notes'
 }


### PR DESCRIPTION
Somehow both sharing modals of cozy-notes ended with a "Files" docType,
which creates obviously many issues in terms of sharing privileges.
It is to be reviewed why these faulty changes were made in the first place.

To add to that, I don't think it is possible to test this to prevent future errors here. It's just direct props injection, so it's 100% declarative. A test would only be the implementation of what it is testing