### PR TITLE
fix note folder path in HeaderNotePath

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,10 @@
+# 1.22.0
+
+## 🐛 Bug Fixes
+
+* Note folder path in HeaderNotePath
+* UseFileWithPath can handle file without name prop
+
 # 1.21.0
 ## ✨ Features
 
@@ -6,7 +13,7 @@
 
 ## 🐛 Bug Fixes
 
-* Do not force drive slug when clicking on BackFromEditing button  
+* Do not force drive slug when clicking on BackFromEditing button
 * Font size on iOS devices
 
 ## 🔧 Tech
@@ -16,16 +23,16 @@
 
 # 1.20.0
 ## ✨ Features
-* Handle sharing modal as route 
+* Handle sharing modal as route
 
 ## 🐛 Bug Fixes
 
-* Don't open mobile browser on click 
-* Display AppTitle on mobile 
-* Improve title styling in mobile 
-* Sharing note with empty title 
-* Update cozy-sharing to remove email sharing 
-* Apply correct documentType on shareModals 
+* Don't open mobile browser on click
+* Display AppTitle on mobile
+* Improve title styling in mobile
+* Sharing note with empty title
+* Update cozy-sharing to remove email sharing
+* Apply correct documentType on shareModals
 
 
 ## 🔧 Tech

--- a/src/components/HeaderNotePath.jsx
+++ b/src/components/HeaderNotePath.jsx
@@ -10,10 +10,10 @@ import useFileWithPath from 'hooks/useFileWithPath'
 export const HeaderNotePath = ({ file }) => {
   const client = useClient()
   const fileWithPath = useFileWithPath({ cozyClient: client, file })
-  const drivePath = useMemo(() => getDriveLink(client, file.attributes.dirId), [
-    client,
-    file.attributes.dirId
-  ])
+  const drivePath = useMemo(
+    () => getDriveLink(client, file.attributes.dir_id),
+    [client, file.attributes.dir_id]
+  )
 
   return (
     <WithBreakpoints hideOn={Breakpoints.Mobile}>

--- a/src/hooks/useFileWithPath.js
+++ b/src/hooks/useFileWithPath.js
@@ -1,11 +1,25 @@
 import { useEffect, useState } from 'react'
 import { models } from 'cozy-client'
 
+export const normalizeAndAddName = rawFile => {
+  const normalizedFile = models.file.normalize(rawFile)
+
+  if (normalizedFile.name) {
+    return normalizedFile
+  }
+
+  return {
+    name: normalizedFile.attributes?.name ?? undefined,
+    ...normalizedFile
+  }
+}
+
 function useFileWithPath({ cozyClient, file }) {
   const [fileWithPath, setFileWithPath] = useState(undefined)
   useEffect(() => {
     async function getParent(rawFile) {
-      const file = models.file.normalize(rawFile)
+      const file = normalizeAndAddName(rawFile)
+
       try {
         const parent = await cozyClient.query(
           cozyClient.get('io.cozy.files', file.attributes.dir_id)

--- a/src/hooks/useFileWithPath.spec.js
+++ b/src/hooks/useFileWithPath.spec.js
@@ -1,0 +1,40 @@
+import { normalizeAndAddName } from './useFileWithPath'
+
+describe('normalizeAndAddName', () => {
+  it('should work with only id', () => {
+    const res = normalizeAndAddName({ id: 'fileId' })
+
+    expect(res).toStrictEqual({
+      _id: 'fileId',
+      _type: 'io.cozy.files',
+      id: 'fileId',
+      name: undefined
+    })
+  })
+
+  it('should work with id and name', () => {
+    const res = normalizeAndAddName({ id: 'fileId', name: 'fileName' })
+
+    expect(res).toStrictEqual({
+      _id: 'fileId',
+      _type: 'io.cozy.files',
+      id: 'fileId',
+      name: 'fileName'
+    })
+  })
+
+  it('should work with id and name attributes', () => {
+    const res = normalizeAndAddName({
+      id: 'fileId',
+      attributes: { name: 'fileNameFromAttributes' }
+    })
+
+    expect(res).toStrictEqual({
+      _id: 'fileId',
+      _type: 'io.cozy.files',
+      id: 'fileId',
+      attributes: { name: 'fileNameFromAttributes' },
+      name: 'fileNameFromAttributes'
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/aGLLz7aD

Lors de la consultation d'une note, le lien vers son dossier dans le header n'était pas bon