### PR TITLE
fix: preview path to match with cozy-sharing

### DIFF
--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -38,7 +38,7 @@ export enum Slugs {
   Notes = 'notes'
 }
 
-export const SHARING_LOCATION = '/preview/'
+export const SHARING_LOCATION = '/preview'
 
 export enum DocumentTypes {
   Files = 'Files',

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -29,6 +29,7 @@ import {
 } from 'lib/initFromDom'
 
 import flag from 'cozy-flags'
+import { SHARING_LOCATION } from '../../constants/strings'
 
 const manifest = require('../../../manifest.webapp')
 
@@ -77,7 +78,7 @@ const renderApp = function(appLocale, client, isPublic) {
                     <SharingProvider
                       doctype="io.cozy.files"
                       documentType="Notes"
-                      previewPath="/preview/"
+                      previewPath={SHARING_LOCATION}
                     >
                       <App isPublic={isPublic} />
                     </SharingProvider>


### PR DESCRIPTION
```
### ✨ Features

*

### 🐛 Bug Fixes

* Correct preview path to show correct sharing banner for cozy to cozy sharing

### 🔧 Tech

*

```

My previous PR : https://github.com/cozy/cozy-notes/pull/344 only fix the problem to show the banner. Notes preview wasn't matching with cozy-sharing pathname so we show every time the public banner with this new fix we show also the name of the cozy owner.
