### PR TITLE
feat: Increase note row dots menu hit box on mobile

### DIFF
--- a/src/components/notes/List/NoteRow.jsx
+++ b/src/components/notes/List/NoteRow.jsx
@@ -11,7 +11,7 @@ import { SharedRecipients } from 'cozy-sharing'
 import { TableRow, TableCell } from 'cozy-ui/transpiled/react/Table'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import { withClient } from 'cozy-client'
-
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import NoteIcon from 'assets/icons/icon-note-32.svg'
 import styles from 'components/notes/List/list.styl'
 import { AppRoutes } from 'constants/routes'
@@ -22,6 +22,7 @@ import { WithBreakpoints } from './WithBreakpoints'
 import { generateReturnUrlToNotesIndex, getDriveLink } from 'lib/utils'
 
 const NoteRow = ({ note, f, t, client }) => {
+  const { isMobile } = useBreakpoints()
   const location = useLocation()
   const { filename, extension } = CozyFile.splitFilename(note)
   const [isMenuOpen, setMenuOpen] = useState(false)
@@ -115,9 +116,9 @@ const NoteRow = ({ note, f, t, client }) => {
           </TableCell>
         </WithBreakpoints>
 
-        <TableCell className={styles.tableCell}>
+        <TableCell className={styles.tableCell} onClick={isMobile && openMenu}>
           <span ref={menuTriggerRef}>
-            <IconButton onClick={openMenu}>
+            <IconButton onClick={!isMobile && openMenu}>
               <Icon icon="dots" />
             </IconButton>
           </span>

--- a/src/components/notes/List/NoteRow.jsx
+++ b/src/components/notes/List/NoteRow.jsx
@@ -83,17 +83,20 @@ const NoteRow = ({ note, f, t, client }) => {
         >
           <Icon icon={NoteIcon} size={32} className="u-mr-1 u-flex-shrink-0" />
 
-          <div className="u-flex-grow-1">
-            <span className="u-charcoalGrey u-ellipsis">{filename}</span>
-
-            <WithBreakpoints hideOn={Breakpoints.Mobile}>
-              <span className="u-ellipsis">{extension}</span>
-            </WithBreakpoints>
-
-            <WithBreakpoints showOn={Breakpoints.Mobile}>
+          {isMobile ? (
+            <div
+              className="u-flex u-flex-column u-flex-grow-1"
+              style={{ minWidth: 0 }}
+            >
+              <span className="u-charcoalGrey u-ellipsis">{filename}</span>
               <NotePath drivePath={drivePath} path={note.path} noLink />
-            </WithBreakpoints>
-          </div>
+            </div>
+          ) : (
+            <div className="u-flex-grow-1">
+              <span className="u-charcoalGrey u-ellipsis">{filename}</span>
+              <span className="u-ellipsis">{extension}</span>
+            </div>
+          )}
         </TableCell>
 
         <WithBreakpoints hideOn={Breakpoints.Mobile}>


### PR DESCRIPTION
red = before
blue = after

<img width="384" alt="Screenshot 2022-12-19 at 15 14 49" src="https://user-images.githubusercontent.com/10849491/208446381-a24fb01d-ced2-4923-8dbb-bfa876e204d9.png">


```
### ✨ Features

* Increase note row dots menu hit box on mobile

### Bugfix

* Fix text ellipsis on mobile note name

```
