### PR TITLE
feat: Use token from body instead of sharecode in URL

### DIFF
--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -121,8 +121,8 @@ export const initApp = () => {
   const protocol = window.location ? window.location.protocol : 'https:'
 
   const shareCode = getPublicSharecode()
-  const token = shareCode || data.token
-  const isPublic = Boolean(shareCode || !token || token == '')
+  const token = data.token
+  const isPublic = Boolean(shareCode)
 
   // initialize the client to interact with the cozy stack
   const client = new CozyClient({

--- a/src/targets/browser/index.spec.jsx
+++ b/src/targets/browser/index.spec.jsx
@@ -3,7 +3,8 @@ import { getDataset } from 'lib/initFromDom'
 
 jest.mock('lib/initFromDom', () => ({
   ...jest.requireActual('lib/initFromDom'),
-  getDataset: jest.fn().mockReturnValue({})
+  getDataset: jest.fn().mockReturnValue({}),
+  getPublicSharecode: jest.fn().mockReturnValue('ABCD')
 }))
 
 jest.mock('@atlaskit/editor-core/i18n', () => ({
@@ -12,10 +13,6 @@ jest.mock('@atlaskit/editor-core/i18n', () => ({
 }))
 
 describe('app init', () => {
-  afterEach(() => {
-    jest.resetAllMocks()
-  })
-
   it('loads with the users locale', () => {
     getDataset.mockReturnValue({ locale: 'fr', app: {} })
     const { appLocale } = initApp()


### PR DESCRIPTION
Shared note preview writable again because token from body had write access.


```
### ✨ Features

* Shared note previews are now writable if write access is granted.
```
