### PR TITLE
feat: Update cozy-scripts from 6.3.8 to 7.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "cozy-intent": "^2.0.2",
     "cozy-logger": "^1.9.0",
     "cozy-realtime": "4.0.5",
-    "cozy-scripts": "6.3.8",
+    "cozy-scripts": "7.0.1",
     "cozy-sharing": "^4.7.0",
     "cozy-ui": "^77.6.0",
     "lodash": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7614,10 +7614,10 @@ cozy-release@1.10.0:
   dependencies:
     exec-sh "0.3.2"
 
-cozy-scripts@6.3.8:
-  version "6.3.8"
-  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-6.3.8.tgz#a6618b4bf46a4e20ea57cc1bf434891a6b14ff7a"
-  integrity sha512-Jfjpa4gkFxSzeDFvgtEHF62urdl4ZIHyGKq15ZNzae9IdylKy1+c2V5KER1s1wgJcOWBefAlRG3yiTDx76DkrA==
+cozy-scripts@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-7.0.1.tgz#1a2f6a132bc1fb0ba802be72df4272dc08876566"
+  integrity sha512-mtimk7Mzaao3oqCrSEWHZvuCjIRgQZhzFN+J4DN6xOitxvoyVOHpDABiNMvLnzwkLVd3si5AMURRh68byWC+cg==
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/polyfill" "^7.10.4"


### PR DESCRIPTION
```
### ✨ Features

* Update cozy-scripts from 6.3.8 to 7.0.1
```

Not affected by the breaking change of `cozy-scripts` because `cozy-notes` still uses cozy-bar v7
