### PR TITLE
chore: Add groups on bundlemon

### DIFF
--- a/.bundlemonrc
+++ b/.bundlemonrc
@@ -26,5 +26,19 @@
       "maxSize": "36 KB"
     }
   ],
+  "groups": [
+    {
+      "path": "app/**"
+    },
+    {
+      "path": "public/**"
+    },
+    {
+      "path": "intents/**"
+    },
+    {
+      "path": "vendors/**"
+    }
+  ],
   "reportOutput": ["github"]
 }


### PR DESCRIPTION
This commit is preparation to track change of size after the split of vendors into two parts vendors and atlaskit : https://github.com/cozy/cozy-notes/pull/367

```
### 🔧 Tech

* Add groups on bundlemon
```
