### PR TITLE
chore: Bump version to 1.28.0

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -4,7 +4,7 @@
   "slug": "notes",
   "icon": "icon.svg",
   "categories": ["cozy"],
-  "version": "1.27.0",
+  "version": "1.28.0",
   "licence": "AGPL-3.0",
   "editor": "Cozy",
   "source": "https://github.com/cozy/cozy-notes.git@build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-notes",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "scripts": {
     "analyze": "COZY_SCRIPTS_ANALYZER=true yarn build",
     "build:browser:dev": "cs build --browser --development",


### PR DESCRIPTION

```
### 🔧 Tech

* Bump version to 1.28.0
```
