### PR TITLE
fix: Escape returnURL parameter

### DIFF
--- a/src/components/notes/editor-loading-error.jsx
+++ b/src/components/notes/editor-loading-error.jsx
@@ -1,26 +1,28 @@
 import React from 'react'
 import { Empty } from 'cozy-ui/transpiled/react'
-import { translate } from 'cozy-ui/transpiled/react/I18n'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 function EditorLoadingError(props) {
-  const { t, returnUrl } = props
-
+  const { returnUrl } = props
+  const { t } = useI18n()
   return (
     <Empty
       icon="cross-small"
       title={t(`Error.loading_error_title`)}
       text={
-        <p
-          className="u-mb-half"
-          dangerouslySetInnerHTML={{
-            __html: returnUrl
-              ? t(`Error.loading_error_text_returnUrl`, { url: returnUrl })
-              : t(`Error.loading_error_text_noReturnUrl`)
-          }}
-        />
+        <>
+          <p className="u-mb-half">
+            {t(`Error.loading_error_text_noReturnUrl`)}
+          </p>
+
+          {returnUrl && (
+            <Button variant="text" label={t('Error.back')} href={returnUrl} />
+          )}
+        </>
       }
     />
   )
 }
 
-export default translate()(EditorLoadingError)
+export default EditorLoadingError

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -94,7 +94,7 @@
     "unshared_text": "The owner may have revoked this sharing. You can no longer edit a note at this address.",
     "loading_error_title": "The note couldn't be loaded",
     "loading_error_text_noReturnUrl": "The note may not exists anymore, or our servers may have a temporary glitch. Please try again later.",
-    "loading_error_text_returnUrl": "The note may not exists anymore, or our servers may have a temporary glitch. Please go <a href='%{url}'>back</a> and try again later.",
+    "back": "back",
     "422": "Only images are accepted",
     "unknown_error": "An unexpected error occured",
     "only_one_image": "You cannot drag and drop multiple pictures at the same time"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -94,7 +94,7 @@
     "unshared_text": "Le propriétaire a peut-être révoqué ce partage. Vous ne pouvez plus éditer de note à cette adresse.",
     "loading_error_title": "La note n'a pas pu être chargée",
     "loading_error_text_noReturnUrl": "Cette note n'existe peut-être plus, ou nos serveurs ont peut-être un moment d'égarement. Merci de retenter plus tard.",
-    "loading_error_text_returnUrl": "Cette note n'existe peut-être plus, ou nos serveurs ont peut-être un moment d'égarement. Merci revenir <a href='%{url}'>en arrière</a> et de retenter plus tard.",
+    "back": "Retour",
     "422": "Seules les images sont acceptées",
     "unknown_error": "Une erreur inattendue s'est produite",
     "only_one_image": "Vous ne pouvez pas glisser-déposer plusieurs images en même temps"


### PR DESCRIPTION
Quick fix 

```
### 🔧 Security

* It was possible to inject style in this parameter. CSP was blocking javascript, so this was not too dangerous. 

```

We should rethink this returnURL parameter to see if it still needed or not and maybe check the domain. This param is used at least on Drive when creating a note, in order to go back to Drive when clicking on "Back" and not returning at the root of cozy-notes. 