### PR TITLE
Restore '@atlaskit/calendar' Module Reference

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -47,7 +47,6 @@ const extraConfig = {
         './node_modules/@atlaskit/editor-common/node_modules/@atlaskit/adf-schema'
       ),
       '@atlaskit/media-viewer': path.resolve('./src/plugins/altaskit-unused'),
-      '@atlaskit/calendar': path.resolve('./src/plugins/altaskit-unused'),
       '@atlaskit/user-picker': path.resolve('./src/plugins/altaskit-unused')
     }
   }


### PR DESCRIPTION
In commit 4b7c063097951f2158804f8160f11d7dd4547f4e, the '@atlaskit/calendar' module was removed from the webpack configuration. However, this module is still in use within the application in the DatePicker component of the Note editor.

This PR restores the reference to '@atlaskit/calendar' in the webpack config, fixing the issue introduced by the previous commit and ensuring the application functions as expected.