### PR TITLE
Add intent for editor view

### DIFF
--- a/.bundlemonrc
+++ b/.bundlemonrc
@@ -3,11 +3,11 @@
   "files": [
     {
       "path": "app/notes.<hash>.js",
-      "maxSize": "62 KB"
+      "maxSize": "65 KB"
     },
     {
       "path": "intents/notes.<hash>.js",
-      "maxSize": "1 KB"
+      "maxSize": "50 KB"
     },
     {
       "path": "public/notes.<hash>.js",

--- a/config/webpack.bundle.default.js
+++ b/config/webpack.bundle.default.js
@@ -15,7 +15,7 @@ const configs = [
   require('cozy-scripts/config/webpack.config.eslint'),
   require('cozy-scripts/config/webpack.config.cozy-ui'),
   require('cozy-scripts/config/webpack.config.cozy-ui.react'),
-  require('cozy-scripts/config/webpack.config.intents'),
+  require('./webpack.config.intents'),
   require('cozy-scripts/config/webpack.config.public'),
   require('cozy-scripts/config/webpack.config.pictures'),
   require('cozy-scripts/config/webpack.config.vendors'),

--- a/config/webpack.config.intents.js
+++ b/config/webpack.config.intents.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const intentsConfig = require('cozy-scripts/config/webpack.config.intents')
+
+// We add atlaskit chunk into the chunks list
+intentsConfig.plugins?.[0]?.options?.chunks?.push('atlaskit')
+
+module.exports = intentsConfig

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -32,8 +32,20 @@
       "folder": "/",
       "index": "index.html",
       "public": true
+    },
+    "/intents": {
+      "folder": "/intents",
+      "index": "index.html",
+      "public": false
     }
   },
+  "intents": [
+    {
+      "action": "OPEN",
+      "type": ["io.cozy.notes.documents"],
+      "href": "/intents"
+    }
+  ],
   "permissions": {
     "apps": {
       "description": "Required by the cozy-bar to display the icons of the apps",
@@ -60,6 +72,10 @@
     },
     "groups": {
       "type": "io.cozy.contacts.groups",
+      "verbs": ["GET"]
+    },
+    "intents": {
+      "type": "io.cozy.notes.documents",
       "verbs": ["GET"]
     }
   }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "cozy-flags": "2.8.4",
     "cozy-harvest-lib": "7.2.3",
     "cozy-intent": "^2.0.2",
+    "cozy-interapp": "^0.8.0",
     "cozy-logger": "^1.9.0",
     "cozy-realtime": "4.0.5",
     "cozy-scripts": "8.0.1",

--- a/src/components/intents/IntentEditorView.jsx
+++ b/src/components/intents/IntentEditorView.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import EditorView from 'components/notes/editor-view'
+import SaveButton from 'components/intents/SaveButton'
+
+const IntentEditorView = () => {
+  const { t } = useI18n()
+  const [title, setTitle] = useState('')
+
+  const handleTitleChange = el => {
+    setTitle(el.target.value)
+  }
+
+  return (
+    <EditorView
+      defaultTitle={t('Notes.Editor.title_placeholder')}
+      isIntents
+      onTitleChange={handleTitleChange}
+    >
+      <SaveButton title={title} />
+    </EditorView>
+  )
+}
+
+export default IntentEditorView

--- a/src/components/intents/IntentProvider.jsx
+++ b/src/components/intents/IntentProvider.jsx
@@ -1,0 +1,73 @@
+import React, {
+  useEffect,
+  useMemo,
+  useState,
+  createContext,
+  useContext
+} from 'react'
+
+import { useClient } from 'cozy-client'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+export const IntentContext = createContext()
+
+export const useIntent = () => {
+  const context = useContext(IntentContext)
+
+  if (!context) {
+    throw new Error('useIntent must be used within a IntentProvider')
+  }
+  return context
+}
+
+const IntentProvider = ({ intentId, children }) => {
+  const client = useClient()
+  const [state, setState] = useState({
+    service: null,
+    intent: null,
+    data: null
+  })
+
+  const value = useMemo(
+    () => ({
+      service: state.service,
+      intent: state.intent,
+      data: state.data
+    }),
+    [state]
+  )
+
+  useEffect(() => {
+    const startService = async () => {
+      let service
+
+      try {
+        service = await client.intents.createService(intentId, window)
+        const intent = service.getIntent()
+        const data = service.getData()
+
+        setState({
+          service,
+          intent,
+          data
+        })
+      } catch (error) {
+        service.throw(error)
+      }
+    }
+
+    if (!state.service) {
+      startService()
+    }
+  }, [client, intentId, state.service])
+
+  if (!state.service) {
+    return <Spinner className="u-m-0" size="xxlarge" middle />
+  }
+
+  return (
+    <IntentContext.Provider value={value}>{children}</IntentContext.Provider>
+  )
+}
+
+export default IntentProvider

--- a/src/components/intents/SaveButton.jsx
+++ b/src/components/intents/SaveButton.jsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react'
+
+import { useClient } from 'cozy-client'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Buttons from 'cozy-ui/transpiled/react/Buttons'
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
+
+import useServiceClient from 'hooks/useServiceClient'
+import useUser from 'hooks/useUser'
+import { useIntent } from 'components/intents/IntentProvider'
+
+const useStyles = makeStyles({
+  root: {
+    position: 'fixed',
+    bottom: 'calc(env(safe-area-inset-bottom) + 1rem)',
+    left: 0
+  }
+})
+
+const SaveButton = ({ title, actions }) => {
+  const { t } = useI18n()
+  const styles = useStyles()
+  const cozyClient = useClient()
+  const { service } = useIntent()
+  const { userName, userId } = useUser({ cozyClient })
+  const serviceClient = useServiceClient({
+    cozyClient,
+    userId,
+    userName
+  })
+  const [isBusy, setIsBusy] = useState(false)
+
+  const handleClick = actions => async () => {
+    try {
+      setIsBusy(true)
+      const doc = await actions.getValue()
+      await serviceClient.create(title, undefined, doc)
+      service.terminate()
+      setIsBusy(false)
+    } catch (error) {
+      service.cancel()
+    }
+  }
+
+  return (
+    <>
+      <style>
+        html .akEditor&gt;div:first-child
+        {'{ bottom: calc(env(safe-area-inset-bottom) + 5rem) }'}
+      </style>
+      <Buttons
+        classes={styles}
+        label={t('Intents.save')}
+        busy={isBusy}
+        fullWidth
+        onClick={handleClick(actions)}
+      />
+    </>
+  )
+}
+
+export default SaveButton

--- a/src/components/notes/__snapshots__/editor-view.spec.jsx.snap
+++ b/src/components/notes/__snapshots__/editor-view.spec.jsx.snap
@@ -21,19 +21,31 @@ exports[`EditorView readOnly when false without a collabProvider should not disa
           <aside
             class="banner"
           />
-          <h1
-            class="MuiTypography-root title MuiTypography-h3 MuiTypography-colorTextPrimary"
-            tag="h1"
+          <div
+            class="MuiFormControl-root MuiTextField-root title MuiFormControl-fullWidth"
+            style="height: 0px;"
           >
-            <textarea
-              class="styles__c-textarea___D7EEH styles__c-textarea--fullwidth___Ih_mg titleInput"
-              placeholder="placeholder"
-              rows="1"
-              style="height: 0px;"
+            <div
+              class="MuiInputBase-root MuiInput-root MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-multiline MuiInput-multiline"
             >
-              title
-            </textarea>
-          </h1>
+              <textarea
+                aria-invalid="false"
+                class="MuiInputBase-input MuiInput-input titleInput MuiInputBase-inputMultiline MuiInput-inputMultiline"
+                placeholder="placeholder"
+                rows="1"
+                style="height: 0px; overflow: hidden;"
+              >
+                title
+              </textarea>
+              <textarea
+                aria-hidden="true"
+                class="MuiInputBase-input MuiInput-input titleInput MuiInputBase-inputMultiline MuiInput-inputMultiline"
+                readonly=""
+                style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); width: 100%;"
+                tabindex="-1"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -2,15 +2,16 @@ import React, { useCallback, useRef, useEffect, useMemo, useState } from 'react'
 
 import { Editor, WithEditorActions } from '@atlaskit/editor-core'
 
-import Textarea from 'cozy-ui/transpiled/react/Textarea'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import useEventListener from 'cozy-ui/transpiled/react/hooks/useEventListener'
 import Overlay from 'cozy-ui/transpiled/react/Overlay'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
-import Typography from 'cozy-ui/transpiled/react/Typography'
-import editorConfig from 'components/notes/editor_config'
-import styles from 'components/notes/editor-view.styl'
+import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField'
+
 import { imageUploadProvider } from 'lib/image-upload-provider'
+import editorConfig from 'components/notes/editor_config'
+
+import styles from 'components/notes/editor-view.styl'
 
 function updateTextareaHeight(target) {
   if (target) target.style.height = `${target.scrollHeight}px`
@@ -95,23 +96,21 @@ function EditorView(props) {
               render={() => (
                 <>
                   <aside ref={bannerRef} className={styles.banner}></aside>
-                  <Typography
-                    tag="h1"
+                  <TextField
+                    ref={titleEl}
                     className={styles.title}
-                    variant="h3"
-                    component="h1"
-                  >
-                    <Textarea
-                      ref={titleEl}
-                      rows="1"
-                      readOnly={!!readOnly}
-                      fullwidth={true}
-                      value={title}
-                      onChange={readOnly ? nullCallback : onTitleEvent}
-                      placeholder={defaultTitle}
-                      className={styles.titleInput}
-                    />
-                  </Typography>
+                    multiline
+                    minRows={1}
+                    value={title}
+                    placeholder={defaultTitle}
+                    fullWidth={true}
+                    InputProps={{ disableUnderline: true }}
+                    inputProps={{
+                      className: styles.titleInput,
+                      readOnly: !!readOnly
+                    }}
+                    onChange={readOnly ? nullCallback : onTitleEvent}
+                  />
                 </>
               )}
             />

--- a/src/components/notes/editor-view.jsx
+++ b/src/components/notes/editor-view.jsx
@@ -30,7 +30,9 @@ function EditorView(props) {
     onContentChange,
     readOnly,
     bannerRef,
-    headerMenu
+    headerMenu,
+    isIntent,
+    children
   } = props
   const { t } = useI18n()
 
@@ -68,7 +70,11 @@ function EditorView(props) {
   const [isUploading, setUploading] = useState(false)
 
   return (
-    <article className={styles['note-article']}>
+    <article
+      className={`${styles['note-article']}${
+        isIntent ? ' ' + styles['note-article--intents'] : ''
+      }`}
+    >
       {isUploading && (
         <Overlay>
           <Spinner size="xxlarge" middle />
@@ -93,7 +99,7 @@ function EditorView(props) {
           })}
           contentComponents={
             <WithEditorActions
-              render={() => (
+              render={actions => (
                 <>
                   <aside ref={bannerRef} className={styles.banner}></aside>
                   <TextField
@@ -111,6 +117,11 @@ function EditorView(props) {
                     }}
                     onChange={readOnly ? nullCallback : onTitleEvent}
                   />
+                  {React.Children.map(children, child =>
+                    React.isValidElement(child)
+                      ? React.cloneElement(child, { actions })
+                      : null
+                  )}
                 </>
               )}
             />

--- a/src/components/notes/editor-view.styl
+++ b/src/components/notes/editor-view.styl
@@ -22,35 +22,31 @@ $COZY_BAR_HEIGHT=-3rem
         border-top 1px solid var(--silver)
 
 .title
-    flex-grow 1
-    align-items center
-    margin 0 2rem calc(2 * var(--note-block-spacing)) 2rem
-    text-align center
-    font-size var(--note-title0-fs)
-    color var(--charcoal-grey)
-    line-height var(--note-title0-lh)
-    font-weight 900
-    font-family var(--primaryFont)
-    border none !important
-    padding-top 0 !important
+    height fit-content !important // to override computed value
+    margin-bottom var(--note-block-spacing) !important // to override Mui
 
+    &>div
+        padding 0 !important // to override Mui
+        font-size var(--note-title0-fs)
+        line-height var(--note-title0-lh)
+        font-weight 900
+        font-family Lato-Black, var(--primaryFont)
+        color var(--charcoal-grey)
 
 .titleInput
     &, &:focus, &:hover, &::placeholder
-        border none
-        width 100%
-        padding 0
-        margin 0
-        overflow visible
         text-align center
         font-size var(--note-title0-fs)
         line-height var(--note-title0-lh)
         font-weight 900
         font-family Lato-Black, var(--primaryFont)
-        vertical-align bottom
-        resize none
+        overflow visible
         min-height min-content
-    & ::placeholder
-        color var(--coolGrey)
+
+    &::placeholder
+        opacity 1 !important // to override Mui
+        color var(--coolGrey) !important // to override Mui
+
     &, &:focus, &:hover
-        color var(--charcoalGrey)
+        opacity 1 !important // to override Mui
+        color var(--charcoalGrey) !important // to override Mui

--- a/src/components/notes/editor-view.styl
+++ b/src/components/notes/editor-view.styl
@@ -6,13 +6,16 @@ on medium-screen to give to the bar the needed place. Since we hide the cozy-bar
 on the editor-view we remove this margin
 */
 $COZY_BAR_HEIGHT=-3rem
+
 .note-article
     display flex
     flex-direction column
     height 100%
+    width 100%
 
-    +medium-screen()
-        margin-top $COZY_BAR_HEIGHT
+    &:not(.note-article--intents)
+        +medium-screen()
+            margin-top $COZY_BAR_HEIGHT
 
 .banner
     & > :first-child

--- a/src/lib/collab/stack-client.js
+++ b/src/lib/collab/stack-client.js
@@ -100,16 +100,18 @@ export class ServiceClient {
    * @param {string} title
    * @param {Object} schema
    */
-  async create(title, schema) {
+  async create(title, schema, content) {
     const doc = {
       data: {
         type: 'io.cozy.notes.documents',
         attributes: {
           title: title || this.defaultTitle(),
-          schema: schema || this.schema || defaultSchema
+          schema: schema || this.schema || defaultSchema,
+          content
         }
       }
     }
+
     return this.stackClient.fetchJSON('POST', this.path(), doc)
   }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -106,5 +106,8 @@
       "screenshots/en/screenshot01.png",
       "screenshots/en/screenshot02.png"
     ]
+  },
+  "Intents": {
+    "save": "Save"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -106,5 +106,8 @@
       "screenshots/fr/screenshot01.png",
       "screenshots/fr/screenshot02.png"
     ]
+  },
+  "Intents": {
+    "save": "Enregistrer"
   }
 }

--- a/src/targets/intents/index.ejs
+++ b/src/targets/intents/index.ejs
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="{{.Locale}}">
+<head>
+  <meta charset="utf-8">
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  {{.ThemeCSS}}
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
+  <meta name="theme-color" content="#ffffff">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
+  <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
+    <link rel="stylesheet" href="<%- file %>">
+  <% }); %>
+</head>
+<div
+  role="application"
+  data-cozy="{{.CozyData}}"
+>
+<% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
+  <script src="<%- file %>"></script>
+<% }); %>

--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -1,0 +1,56 @@
+import 'cozy-ui/dist/cozy-ui.utils.min.css'
+import 'cozy-ui/transpiled/react/stylesheet.css'
+import 'styles/index.css'
+
+import React from 'react'
+import { render } from 'react-dom'
+
+import Intents from 'cozy-interapp'
+import CozyClient, { CozyProvider } from 'cozy-client'
+import flag from 'cozy-flags'
+import I18n from 'cozy-ui/transpiled/react/I18n'
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
+
+const manifest = require('../../../manifest.webapp')
+
+import { getDataset, getDataOrDefault } from 'lib/initFromDom'
+import IntentEditorView from 'components/intents/IntentEditorView'
+import IntentProvider from 'components/intents/IntentProvider'
+
+document.addEventListener('DOMContentLoaded', () => {
+  const data = getDataset()
+  const token = data.token
+  const appSlug = getDataOrDefault(data.app.slug, manifest.slug)
+  const appVersion = getDataOrDefault(data.app.version, manifest.version)
+
+  const protocol = window.location.protocol
+  const client = new CozyClient({
+    uri: `${protocol}//${data.domain}`,
+    token,
+    appMetadata: {
+      slug: appSlug,
+      version: appVersion
+    }
+  })
+  const intents = new Intents({ client })
+  client.intents = intents
+  client.registerPlugin(flag.plugin)
+
+  const intentId = new URLSearchParams(window.location.search).get('intent')
+
+  render(
+    <I18n
+      lang={data.locale}
+      dictRequire={lang => require(`../../locales/${lang}`)}
+    >
+      <CozyProvider client={client}>
+        <IntentProvider intentId={intentId}>
+          <MuiCozyTheme>
+            <IntentEditorView />
+          </MuiCozyTheme>
+        </IntentProvider>
+      </CozyProvider>
+    </I18n>,
+    document.querySelector('[role=application]')
+  )
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7602,6 +7602,11 @@ cozy-interapp@^0.5.4:
   resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.5.7.tgz#75cafe1732ad660e2caf1ccf412f302594705f39"
   integrity sha512-laIL/ATYV9oZnmqS+LMoO9qzk8XjJ1v2/YrA1Po2rI8ia/MDgjYO07424x2RuvHhNOBPGjD+JmqwQ0rNDlLW+Q==
 
+cozy-interapp@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.8.0.tgz#ca6749fcc674603269cf861fe808fc1a1add409c"
+  integrity sha512-oXz0HjMLmUWjhVZjZoqVL6llZDLE7v0Hv+kDT8b3s/0hF7Wa9MISBsjJ9sAJbRcJUGfnYNcwBu39F8zZNvMHuQ==
+
 cozy-logger@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.10.0.tgz#c040081976921c73021f0acc81d515700241a3f1"


### PR DESCRIPTION
On ajoute la possibilité d'ouvrir l'éditeur de note via un intent. Depuis l'itent il y a donc une page qui permet d'écrire le contenu de la note, et un bouton enrgister afin de "terminer" le service de l'intent et de sauvegarder la note.




```
### ✨ Features

* Add intent for editor view

```