### PR TITLE
Fix/menu on mobile

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -4,7 +4,7 @@
   "slug": "notes",
   "icon": "icon.svg",
   "categories": ["cozy"],
-  "version": "1.32.0",
+  "version": "1.33.0",
   "licence": "AGPL-3.0",
   "editor": "Cozy",
   "source": "https://github.com/cozy/cozy-notes.git@build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-notes",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "scripts": {
     "analyze": "COZY_SCRIPTS_ANALYZER=true yarn build",
     "build:browser:dev": "cs build --browser --development",

--- a/src/ui/DropdownMenu/index.tsx
+++ b/src/ui/DropdownMenu/index.tsx
@@ -111,10 +111,6 @@ export default class DropdownMenuWrapper extends PureComponent<Props, State> {
       isOpen,
       zIndex
     } = this.props
-    const isCellPopup = items[0].items.some(
-      ({ content }) => content === 'Cell background'
-    )
-    const position = isCellPopup ? popupPlacement.join(' ') : 'top left'
 
     return (
       <Popup
@@ -131,7 +127,7 @@ export default class DropdownMenuWrapper extends PureComponent<Props, State> {
         <DropListWithOutsideListeners
           isOpen={true}
           appearance="tall"
-          position={position}
+          position={popupPlacement.join(' ')}
           shouldFlip={false}
           shouldFitContainer={true}
           isTriggerNotTabbable={true}


### PR DESCRIPTION
before 
<img width="1520" alt="Capture d’écran 2023-11-08 à 16 37 12" src="https://github.com/cozy/cozy-notes/assets/1107936/a76dd457-bfd5-4007-b2e7-3c233baaf1d0">

after 
<img width="1520" alt="Capture d’écran 2023-11-08 à 16 36 46" src="https://github.com/cozy/cozy-notes/assets/1107936/96943212-e2fd-43f5-8f36-254bca8aec49">


But @acezard I don't know what you've been trying to fix with the : 
```
 const isCellPopup = items[0].items.some(
      ({ content }) => content === 'Cell background'
    )
    const position = isCellPopup ? popupPlacement.join(' ') : 'top left'
 ```
 
 This is something related to "Cell background", but do you remember what was the issue? It seems to work well when I test but I should miss something. 