### PR TITLE
fix: Add margin-bottom to actionList

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -495,3 +495,7 @@ Here we set it to 26px because: 12px (from .code-content padding top) + 14px (fr
 .ProseMirror .code-block .line-number-gutter {
     padding: 26px 8px !important;
 }
+
+.ProseMirror div[data-task-list-local-id] {
+    margin-bottom: var(--note-block-spacing) !important;
+}


### PR DESCRIPTION
Action list is not considered as a "block" so it doesn't get the right margin-bottom.

The result was that, when an action list was at the bottom at the text-area, the toolbar was overridden it.

This fix the issue.


