### PR TITLE
[VO-126] fix: Infinite loop after version update

### DIFF
--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -100,7 +100,7 @@ export default function Editor(props) {
   useDebugValue('notes.returnUrl', returnUrl)
 
   // rendering
-  if (status === 'loaded' && fileResult.fetchStatus === 'loaded') {
+  if (doc && file) {
     return (
       <>
         <RealTimeQueries doctype="io.cozy.files" />


### PR DESCRIPTION
When we format the document, we update the version if necessary. In this case, it updates the io.cozy.files document, which then requests the file a second time. As the two conditions to display the editor are no longer met, this hides it. The editor before hide force save to avoid data lost when closing the page. This relaunch an other request. This created an endless loop where only the loading state was displayed.

This commit corrects this problem by checking whether the object exists instead of checking the state of the request.