### PR TITLE
fix: update note deleted success dialog (VO-152)

### DIFF
--- a/src/components/notes/List/NoteRow.jsx
+++ b/src/components/notes/List/NoteRow.jsx
@@ -45,7 +45,7 @@ const NoteRow = ({ note, f, t, client }) => {
     try {
       await client.destroy(note)
       setMenuOpen(false)
-      showAlert(t('Notes.Delete.deleted'), 'info')
+      showAlert(t('Notes.Delete.deleted'), 'success')
     } catch (error) {
       showAlert(t('Notes.Delete.failed'), 'error')
     }


### PR DESCRIPTION
### 🐛 Bug Fixes

* Success dialog when deleting a note will have the correct color

