### PR TITLE
fix: avoid infinite loop on schema update (VO-312)

### DIFF
--- a/src/components/notes/NoteProvider.jsx
+++ b/src/components/notes/NoteProvider.jsx
@@ -46,7 +46,10 @@ const NoteProvider = ({ children, noteId, readOnly = false }) => {
         // to be able to use the latest features brought by
         // the new schema
         if (!readOnly && doc.schemaVersion !== getSchemaVersion()) {
-          doc = await serviceClient.updateSchema(noteId, schemaOrdered)
+          // Only attempt update if not previously failed, as this would trigger an infinite loop
+          if (status !== 'failed') {
+            doc = await serviceClient.updateSchema(noteId, schemaOrdered)
+          }
         }
         setTitle(doc.title || '')
         setFormatedDocument(doc)


### PR DESCRIPTION
This PR addresses a critical issue where the application entered an infinite loop of attempting to update a note's schema after a failure was encountered. The root cause was identified as a missing condition to halt further attempts once a `404 Not Found` error occurred during the schema update process.

**Modifications:**

- Introduced a conditional check to prevent the `updateSchema` function from being invoked if the previous attempt resulted in a 'failed' status.
- Ensured that the application does not retry the update after setting the status to 'failed', effectively breaking out of the infinite loop.

**Code Changes:**

```javascript
// Added check to prevent update if the last status was 'failed'
if (status !== 'failed') { 
  doc = await serviceClient.updateSchema(noteId, schemaOrdered)
}
```

**Impact:**

- Prevents the application from making redundant and unsuccessful attempts to update a note's schema when it's not possible to do so.


**Testing:**

- Manual tests were conducted to ensure that the application no longer enters an infinite loop upon a failed schema update.

```
### ✨ Features

*

### 🐛 Bug Fixes

* Fixed a scenario where a deleted note would load infinitely

### 🔧 Tech

*
```
