### PR TITLE
fix: set shouldFlip to true in dropdownMenu (VO-582)

### DIFF
--- a/src/ui/DropdownMenu/index.tsx
+++ b/src/ui/DropdownMenu/index.tsx
@@ -128,7 +128,7 @@ export default class DropdownMenuWrapper extends PureComponent<Props, State> {
           isOpen={true}
           appearance="tall"
           position={popupPlacement.join(' ')}
-          shouldFlip={false}
+          shouldFlip={true} // flip the dropdown up if there is not enough space below
           shouldFitContainer={true}
           isTriggerNotTabbable={true}
           handleClickOutside={this.handleClose}


### PR DESCRIPTION
### 🐛 Bug Fixes

* In mobile view, the dropdown menu in the toolbar was displaying in part below the viewport. It will now flip automatically and display above the toolbar if needed


