### PR TITLE
fix: Do not use dataproxy for public sharings

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -192,13 +192,21 @@ const App = ({ isPublic }) => {
 }
 
 const WrappedApp = props => (
-  <DataProxyProvider>
+  <DataProxyWrapper isPublic={props?.isPublic}>
     <BarProvider>
       <BreakpointsProvider>
         <App {...props} />
       </BreakpointsProvider>
     </BarProvider>
-  </DataProxyProvider>
+  </DataProxyWrapper>
 )
+
+const DataProxyWrapper = ({ children, isPublic }) => {
+  if (isPublic) {
+    // Do not include DataProxy for public sharings
+    return children
+  }
+  return <DataProxyProvider>{children}</DataProxyProvider>
+}
 
 export default WrappedApp


### PR DESCRIPTION
In the case of public sharing, we try to get an intent, which redirects to the sso as the recipient is not logged in. And this redirection is blocked by the CSP, so it silently fails.