### PR TITLE
feat: Allow returnUrl if in public view

### DIFF
--- a/src/components/header_menu.jsx
+++ b/src/components/header_menu.jsx
@@ -24,6 +24,7 @@ import { WithBreakpoints } from './notes/List/WithBreakpoints'
  * @param {ReactNode} props.leftComponent - The left component.
  * @param {ReactNode} props.rightComponent - The right component.
  * @param {boolean} props.isPublic - Indicates if the component is public.
+ * @param {boolean} props.hasBackButton - Indicates if the component has a back button.
  * @param {import('cozy-client/types').IOCozyFile} props.file - The file associated with the editor.
  * @param {ReactNode} props.bannerComponent - The banner component.
  */
@@ -32,6 +33,7 @@ const HeaderMenu = ({
   leftComponent,
   rightComponent,
   isPublic,
+  hasBackButton,
   file,
   bannerComponent
 }) => {
@@ -40,7 +42,11 @@ const HeaderMenu = ({
 
   return (
     <header className={styles['header']}>
-      <div className={styles['header-menu']}>
+      <div
+        className={`${styles['header-menu']} ${
+          isPublic ? styles['public-view'] : ''
+        }`}
+      >
         <WithBreakpoints hideOn={Breakpoints.Mobile}>
           <AppLinker app={{ slug: Slugs.Home }} href={homeHref}>
             {({ href }) => (
@@ -59,7 +65,9 @@ const HeaderMenu = ({
 
           <Divider
             orientation="vertical"
-            className={`u-ml-1 u-mt-half u-mb-half ${isPublic ? 'u-mr-1' : ''}`}
+            className={`u-ml-1 u-mt-half u-mb-half ${
+              hasBackButton ? '' : 'u-mr-1'
+            }`}
             flexItem
           />
         </WithBreakpoints>
@@ -75,7 +83,7 @@ const HeaderMenu = ({
             />
           </WithBreakpoints>
 
-          <div className={`${isPublic ? 'u-ml-1' : ''}`}>
+          <div>
             <Typography>
               <strong>{filename}</strong>
             </Typography>

--- a/src/components/notes/back_from_editing.jsx
+++ b/src/components/notes/back_from_editing.jsx
@@ -68,7 +68,7 @@ export default function BackFromEditing({ returnUrl, file, requestToLeave }) {
   const isPublic = useContext(IsPublicContext)
   const client = useClient()
 
-  if (isPublic) {
+  if (isPublic && !returnUrl) {
     return null
   }
 

--- a/src/components/notes/editor.jsx
+++ b/src/components/notes/editor.jsx
@@ -153,6 +153,7 @@ export default function Editor(props) {
                 collabProvider.serviceClient.cozyClient.getStackClient().uri
               }
               isPublic={isPublic}
+              hasBackButton={!isPublic || (isPublic && returnUrl)}
               file={file}
             />
           }

--- a/src/hooks/useReturnUrl.jsx
+++ b/src/hooks/useReturnUrl.jsx
@@ -6,6 +6,15 @@ function useReturnUrl({ returnUrl, cozyClient, doc }) {
   const isPublic = useContext(IsPublicContext)
 
   return useMemo(() => {
+    // If we are in public, we do not want any default value for returnUrl
+    if (isPublic) {
+      if (returnUrl) {
+        return returnUrl
+      } else {
+        return undefined
+      }
+    }
+
     if (returnUrl) {
       return returnUrl
     } else if (doc) {


### PR DESCRIPTION
Shared drive notes are loaded from the owner instance so "in public" and we want a returnUrl.